### PR TITLE
Add structured JSON logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
 
 [Scripts](docs/scripts.md)
 
+## Logging
+
+httphq logs to stdout as structured JSON via the standard library's `log/slog` — one JSON object per line, with no log files or shipping built in, so any collector can pick the logs up. Field names follow OpenTelemetry conventions (`service.name`, `http.request.method`, `url.path`, `http.response.status_code`, ...). Every request gets a correlation `request_id` (a valid inbound `X-Request-Id` is reused, otherwise one is minted) that is echoed back on the response header and stamped onto every log line emitted while handling that request. Each request produces one access-log line; headers and bodies are never logged, paths are logged without their query string, and a denylist masks sensitive keys as a backstop. The level defaults to `info` in production (`debug` elsewhere) and is overridable with `LOG_LEVEL`; Kubernetes probe traffic to `/api/health` logs at `debug` so it stays out of production logs.
+
 ## License
 
 [MIT](https://opensource.org/licenses/MIT)

--- a/src/application.go
+++ b/src/application.go
@@ -1,8 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -23,6 +24,7 @@ import (
 	"gorm.io/datatypes"
 
 	"httphq/src/database"
+	"httphq/src/logging"
 )
 
 const (
@@ -150,6 +152,14 @@ func trimSpace(s string) string {
 }
 
 func main() {
+	/* Logging */
+
+	env := os.Getenv("APPLICATION_ENV")
+	if env == "" {
+		env = "development"
+	}
+	logging.Init("httphq", env)
+
 	/* Database */
 
 	database.Connect("file:local.db?_journal_mode=WAL&_busy_timeout=5000&_synchronous=NORMAL")
@@ -165,9 +175,10 @@ func main() {
 	everyFiveMinutes := "*/5 * * * *"
 	if _, err := c.AddFunc(everyFiveMinutes, func() {
 		threshold := time.Now().Add(-1 * 4 * time.Hour)
-		database.DeleteOldRequests(threshold)
+		database.DeleteOldRequests(context.Background(), threshold)
 	}); err != nil {
-		log.Fatalln(err)
+		slog.Error("cron job registration failed", "err", err)
+		os.Exit(1)
 	}
 
 	c.Start()
@@ -191,6 +202,10 @@ func main() {
 		TrustProxy:  true,
 		ProxyHeader: fiber.HeaderXForwardedFor,
 	})
+
+	// Runs first so every request — including rate-limited ones — gets a
+	// correlation ID and a structured access-log line.
+	application.Use(requestLogger)
 
 	maxRequestsPerMinute := 9999
 	if isProduction {
@@ -241,7 +256,7 @@ func main() {
 		endpointID := kws.Params("endpoint")
 		kws.SetAttribute("endpointID", endpointID)
 		registry.add(endpointID, kws.UUID)
-		log.Printf("%s connected to WS\n", endpointID)
+		slog.Info("websocket connected", "endpoint_id", endpointID)
 	}))
 
 	socketio.On(socketio.EventDisconnect, func(ep *socketio.EventPayload) {
@@ -262,7 +277,7 @@ func main() {
 		return c.JSON(fiber.Map{
 			"host":         string(c.Request().Host()),
 			"isProduction": isProduction,
-			"requests":     database.CountRequests(),
+			"requests":     database.CountRequests(c.Context()),
 			"sockets":      registry.count(),
 		})
 	})
@@ -270,7 +285,7 @@ func main() {
 	application.Get("/api/endpoints/:endpoint/requests", func(c fiber.Ctx) error {
 		endpointID := c.Params("endpoint")
 		search := c.Query("search")
-		requests := database.GetRequestsForEndpointID(endpointID, search, 128)
+		requests := database.GetRequestsForEndpointID(c.Context(), endpointID, search, 128)
 		return c.JSON(fiber.Map{
 			"requests": requests,
 		})
@@ -278,13 +293,13 @@ func main() {
 
 	application.Delete("/api/endpoints/:endpoint/requests", func(c fiber.Ctx) error {
 		endpointID := c.Params("endpoint")
-		database.DeleteRequestsForEndpointID(endpointID)
+		database.DeleteRequestsForEndpointID(c.Context(), endpointID)
 		return c.SendStatus(http.StatusOK)
 	})
 
 	application.Delete("/api/endpoints/:endpoint/requests/:request", func(c fiber.Ctx) error {
 		requestUUID := c.Params("request")
-		database.DeleteRequestForUUID(requestUUID)
+		database.DeleteRequestForUUID(c.Context(), requestUUID)
 		return c.SendStatus(http.StatusOK)
 	})
 
@@ -318,7 +333,7 @@ func main() {
 
 	application.Post("/endpoint", func(c fiber.Ctx) error {
 		endpointID := haikuMaker.Haikunate()
-		log.Printf("Created endpoint %s\n", endpointID)
+		slog.InfoContext(c.Context(), "endpoint created", "endpoint_id", endpointID)
 		return c.Redirect().To("/" + endpointID)
 	})
 
@@ -372,7 +387,7 @@ func main() {
 		}
 		jsonHeaders, err := json.Marshal(flatHeaders)
 		if err != nil {
-			log.Println(err)
+			slog.ErrorContext(c.Context(), "request header marshal failed", "err", err)
 		}
 
 		request := database.Request{
@@ -385,14 +400,14 @@ func main() {
 			Body:        string(body),
 			Headers:     datatypes.JSON(jsonHeaders),
 		}
-		database.CreateRequest(&request)
+		database.CreateRequest(c.Context(), &request)
 
 		// Fan-out to subscribed WS clients. Marshal once, then dispatch
 		// asynchronously so a slow client doesn't stall the capture handler.
 		if uuids := registry.uuidsFor(endpointID); len(uuids) > 0 {
 			marshalled, marshalErr := json.Marshal(request)
 			if marshalErr != nil {
-				log.Println(marshalErr)
+				slog.ErrorContext(c.Context(), "websocket payload marshal failed", "err", marshalErr)
 			} else {
 				go socketio.EmitToList(uuids, marshalled)
 			}
@@ -411,6 +426,9 @@ func main() {
 		host = ":"
 	}
 	address := host + strconv.Itoa(port)
-	log.Println("Listening on " + address)
-	log.Fatalln(application.Listen(address))
+	slog.Info("server listening", "address", address)
+	if err := application.Listen(address); err != nil {
+		slog.Error("server exited", "err", err)
+		os.Exit(1)
+	}
 }

--- a/src/database/database.go
+++ b/src/database/database.go
@@ -1,8 +1,9 @@
 package database
 
 import (
-	"log"
-	"strconv"
+	"context"
+	"log/slog"
+	"os"
 	"time"
 
 	"github.com/glebarez/sqlite"
@@ -25,38 +26,40 @@ type Request struct {
 var DB *gorm.DB
 
 func Connect(dsn string) *gorm.DB {
-	log.Println("Connecting to database...")
+	slog.Info("connecting to database")
 
 	var err error
 
 	DB, err = gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 
 	if err != nil {
-		panic("failed to connect database")
+		slog.Error("database connection failed", "err", err)
+		os.Exit(1)
 	}
 
-	log.Println("Connected to database")
+	slog.Info("database connected")
 
-	log.Println("Migrating database")
+	slog.Info("migrating database")
 
 	if err := DB.AutoMigrate(&Request{}); err != nil {
-		panic("failed to auto-migrate database")
+		slog.Error("database migration failed", "err", err)
+		os.Exit(1)
 	}
 
-	log.Println("Migrated database")
+	slog.Info("database migrated")
 	return DB
 }
 
-func CountRequests() int64 {
+func CountRequests(ctx context.Context) int64 {
 	var count int64
 	result := DB.Model(&Request{}).Count(&count)
 	if result.Error != nil {
-		log.Println(result.Error)
+		slog.ErrorContext(ctx, "count requests failed", "err", result.Error)
 	}
 	return count
 }
 
-func GetRequestsForEndpointID(endpointID string, search string, limit int) []Request {
+func GetRequestsForEndpointID(ctx context.Context, endpointID string, search string, limit int) []Request {
 	var items []Request
 	result := DB.
 		Where(&Request{EndpointID: endpointID}).
@@ -66,36 +69,36 @@ func GetRequestsForEndpointID(endpointID string, search string, limit int) []Req
 		Order("created_at DESC").
 		Find(&items)
 	if result.Error != nil {
-		log.Println(result.Error)
+		slog.ErrorContext(ctx, "get requests failed", "err", result.Error, "endpoint_id", endpointID)
 	}
 	return items
 }
 
-func CreateRequest(request *Request) {
+func CreateRequest(ctx context.Context, request *Request) {
 	result := DB.Create(&request)
 	if result.Error != nil {
-		log.Println(result.Error)
+		slog.ErrorContext(ctx, "create request failed", "err", result.Error)
 	}
 }
 
-func DeleteRequestsForEndpointID(endpointID string) {
+func DeleteRequestsForEndpointID(ctx context.Context, endpointID string) {
 	result := DB.Where(&Request{EndpointID: endpointID}).Delete(&Request{})
 	if result.Error != nil {
-		log.Println(result.Error)
+		slog.ErrorContext(ctx, "delete requests failed", "err", result.Error, "endpoint_id", endpointID)
 	}
 }
 
-func DeleteRequestForUUID(UUID string) {
+func DeleteRequestForUUID(ctx context.Context, UUID string) {
 	result := DB.Where(&Request{UUID: UUID}).Delete(&Request{})
 	if result.Error != nil {
-		log.Println(result.Error)
+		slog.ErrorContext(ctx, "delete request failed", "err", result.Error)
 	}
 }
 
-func DeleteOldRequests(threshold time.Time) {
+func DeleteOldRequests(ctx context.Context, threshold time.Time) {
 	result := DB.Where("created_at < ?", threshold).Delete(&Request{})
 	if result.Error != nil {
-		log.Println(result.Error)
+		slog.ErrorContext(ctx, "delete old requests failed", "err", result.Error)
 	}
-	log.Println("Deleted " + strconv.Itoa(int(result.RowsAffected)) + " old requests")
+	slog.InfoContext(ctx, "deleted old requests", "count", result.RowsAffected)
 }

--- a/src/database/database_test.go
+++ b/src/database/database_test.go
@@ -28,13 +28,13 @@ func TestCountRequests(t *testing.T) {
 	database.Connect(":memory:")
 
 	// It should return 0 if no items exist
-	assert.Equal(t, int64(0), database.CountRequests())
+	assert.Equal(t, int64(0), database.CountRequests(t.Context()))
 
 	// It should return the amount of existing items
 	var n = 3
 	for i := 0; i < n; i++ {
 		ID := fmt.Sprint(i)
-		database.CreateRequest(&database.Request{
+		database.CreateRequest(t.Context(), &database.Request{
 			UUID:       ID,
 			EndpointID: ID,
 			IP:         ID,
@@ -43,7 +43,7 @@ func TestCountRequests(t *testing.T) {
 			Body:       "test",
 		})
 	}
-	assert.Equal(t, int64(n), database.CountRequests())
+	assert.Equal(t, int64(n), database.CountRequests(t.Context()))
 }
 
 func TestGetRequestsForEndpointID(t *testing.T) {
@@ -54,10 +54,10 @@ func TestGetRequestsForEndpointID(t *testing.T) {
 	var items []database.Request
 
 	// It should return an empty array if no items exist
-	items = database.GetRequestsForEndpointID(endpointID, "", 32)
+	items = database.GetRequestsForEndpointID(t.Context(),endpointID, "", 32)
 	assert.Equal(t, []database.Request{}, items)
 
-	database.CreateRequest(&database.Request{
+	database.CreateRequest(t.Context(), &database.Request{
 		UUID:       "uuid-1",
 		EndpointID: endpointID,
 		IP:         "test-ip",
@@ -66,7 +66,7 @@ func TestGetRequestsForEndpointID(t *testing.T) {
 		Body:       "test-body-1",
 		Headers:    datatypes.JSON(`{ "Test": "Test-Header-1" }`),
 	})
-	database.CreateRequest(&database.Request{
+	database.CreateRequest(t.Context(), &database.Request{
 		UUID:       "uuid-2",
 		EndpointID: endpointID,
 		IP:         "test-ip",
@@ -75,7 +75,7 @@ func TestGetRequestsForEndpointID(t *testing.T) {
 		Body:       "test-body-2",
 		Headers:    datatypes.JSON(`{ "Test": "Test-Header-2" }`),
 	})
-	database.CreateRequest(&database.Request{
+	database.CreateRequest(t.Context(), &database.Request{
 		UUID:       "uuid-3",
 		EndpointID: "other-id",
 		IP:         "test-ip",
@@ -86,7 +86,7 @@ func TestGetRequestsForEndpointID(t *testing.T) {
 	})
 
 	// It should return items with the correct shape
-	items = database.GetRequestsForEndpointID(endpointID, "", 1)
+	items = database.GetRequestsForEndpointID(t.Context(),endpointID, "", 1)
 	assert.Equal(t, "uuid-2", items[0].UUID)
 	assert.Equal(t, endpointID, items[0].EndpointID)
 	assert.Equal(t, "test-ip", items[0].IP)
@@ -97,34 +97,34 @@ func TestGetRequestsForEndpointID(t *testing.T) {
 	assert.Equal(t, time.Now().Format(time.ANSIC), items[0].CreatedAt.Format(time.ANSIC))
 
 	// It should only return items with the specified endpoint id
-	items = database.GetRequestsForEndpointID(endpointID, "", 32)
+	items = database.GetRequestsForEndpointID(t.Context(),endpointID, "", 32)
 	assert.Equal(t, 2, len(items))
 
 	// It should not return more items than the limit
-	items = database.GetRequestsForEndpointID(endpointID, "", 1)
+	items = database.GetRequestsForEndpointID(t.Context(),endpointID, "", 1)
 	assert.Equal(t, 1, len(items))
 
 	// It should return return items ordered by creation date, newest first
-	items = database.GetRequestsForEndpointID(endpointID, "", 32)
+	items = database.GetRequestsForEndpointID(t.Context(),endpointID, "", 32)
 	assert.Equal(t, "test-body-2", items[0].Body)
 	assert.Equal(t, "test-body-1", items[1].Body)
 
 	// It should not apply any additional filtering if the search string is empty
-	items = database.GetRequestsForEndpointID(endpointID, "", 32)
+	items = database.GetRequestsForEndpointID(t.Context(),endpointID, "", 32)
 	assert.Equal(t, 2, len(items))
 
 	// It should search the body based on the search string
-	items = database.GetRequestsForEndpointID(endpointID, "test-body", 32)
+	items = database.GetRequestsForEndpointID(t.Context(),endpointID, "test-body", 32)
 	assert.Equal(t, 2, len(items))
 
-	items = database.GetRequestsForEndpointID(endpointID, "test-body-1", 32)
+	items = database.GetRequestsForEndpointID(t.Context(),endpointID, "test-body-1", 32)
 	assert.Equal(t, 1, len(items))
 
 	// It should search the headers based on the search string
-	items = database.GetRequestsForEndpointID(endpointID, "Test-Header", 32)
+	items = database.GetRequestsForEndpointID(t.Context(),endpointID, "Test-Header", 32)
 	assert.Equal(t, 2, len(items))
 
-	items = database.GetRequestsForEndpointID(endpointID, "Test-Header-1", 32)
+	items = database.GetRequestsForEndpointID(t.Context(),endpointID, "Test-Header-1", 32)
 	assert.Equal(t, 1, len(items))
 }
 
@@ -133,7 +133,7 @@ func TestCreateRequest(t *testing.T) {
 
 	endpointID := "test-id"
 
-	database.CreateRequest(&database.Request{
+	database.CreateRequest(t.Context(), &database.Request{
 		UUID:       "test-uuid",
 		EndpointID: endpointID,
 		IP:         "test-ip",
@@ -143,7 +143,7 @@ func TestCreateRequest(t *testing.T) {
 		Headers:    datatypes.JSON(`{ "Test": "Test-Header" }`),
 	})
 
-	items := database.GetRequestsForEndpointID(endpointID, "", 1)
+	items := database.GetRequestsForEndpointID(t.Context(),endpointID, "", 1)
 
 	assert.Equal(t, "test-uuid", items[0].UUID)
 	assert.Equal(t, time.Now().Format(time.ANSIC), items[0].CreatedAt.Format(time.ANSIC))
@@ -152,7 +152,7 @@ func TestCreateRequest(t *testing.T) {
 func TestDeleteRequestsForEndpointID(t *testing.T) {
 	database.Connect(":memory:")
 
-	database.CreateRequest(&database.Request{
+	database.CreateRequest(t.Context(), &database.Request{
 		UUID:       "test-uuid-1",
 		EndpointID: "delete-id",
 		IP:         "test-ip",
@@ -162,7 +162,7 @@ func TestDeleteRequestsForEndpointID(t *testing.T) {
 		Headers:    datatypes.JSON(`{ "Test": "Test-Header" }`),
 	})
 
-	database.CreateRequest(&database.Request{
+	database.CreateRequest(t.Context(), &database.Request{
 		UUID:       "test-uuid-2",
 		EndpointID: "keep-id",
 		IP:         "test-ip",
@@ -172,16 +172,16 @@ func TestDeleteRequestsForEndpointID(t *testing.T) {
 		Headers:    datatypes.JSON(`{ "Test": "Test-Header" }`),
 	})
 
-	database.DeleteRequestsForEndpointID("delete-id")
+	database.DeleteRequestsForEndpointID(t.Context(),"delete-id")
 
-	assert.Equal(t, int64(1), database.CountRequests())
-	assert.Equal(t, "keep-id", database.GetRequestsForEndpointID("keep-id", "", 1)[0].EndpointID)
+	assert.Equal(t, int64(1), database.CountRequests(t.Context()))
+	assert.Equal(t, "keep-id", database.GetRequestsForEndpointID(t.Context(),"keep-id", "", 1)[0].EndpointID)
 }
 
 func TestDeleteRequestForUUID(t *testing.T) {
 	database.Connect(":memory:")
 
-	database.CreateRequest(&database.Request{
+	database.CreateRequest(t.Context(), &database.Request{
 		UUID:       "delete-uuid",
 		EndpointID: "test-id",
 		IP:         "test-ip",
@@ -191,7 +191,7 @@ func TestDeleteRequestForUUID(t *testing.T) {
 		Headers:    datatypes.JSON(`{ "Test": "Test-Header" }`),
 	})
 
-	database.CreateRequest(&database.Request{
+	database.CreateRequest(t.Context(), &database.Request{
 		UUID:       "keep-uuid",
 		EndpointID: "test-id",
 		IP:         "test-ip",
@@ -201,10 +201,10 @@ func TestDeleteRequestForUUID(t *testing.T) {
 		Headers:    datatypes.JSON(`{ "Test": "Test-Header" }`),
 	})
 
-	database.DeleteRequestForUUID("delete-uuid")
+	database.DeleteRequestForUUID(t.Context(),"delete-uuid")
 
-	assert.Equal(t, int64(1), database.CountRequests())
-	assert.Equal(t, "keep-uuid", database.GetRequestsForEndpointID("test-id", "", 1)[0].UUID)
+	assert.Equal(t, int64(1), database.CountRequests(t.Context()))
+	assert.Equal(t, "keep-uuid", database.GetRequestsForEndpointID(t.Context(),"test-id", "", 1)[0].UUID)
 }
 
 func TestDeleteOldRequests(t *testing.T) {
@@ -215,7 +215,7 @@ func TestDeleteOldRequests(t *testing.T) {
 	threshold := time.Now().Add(-1 * 4 * time.Hour)
 
 	// It should delete items created before the threshold
-	database.CreateRequest(&database.Request{
+	database.CreateRequest(t.Context(), &database.Request{
 		UUID:       "uuid-delete",
 		EndpointID: endpointID,
 		IP:         "test-ip",
@@ -225,11 +225,11 @@ func TestDeleteOldRequests(t *testing.T) {
 		Headers:    datatypes.JSON(`{ "Test": "Test-Header" }`),
 		CreatedAt:  threshold.Add(-1 * time.Hour),
 	})
-	database.DeleteOldRequests(threshold)
-	assert.Equal(t, int64(0), database.CountRequests())
+	database.DeleteOldRequests(t.Context(),threshold)
+	assert.Equal(t, int64(0), database.CountRequests(t.Context()))
 
 	// It should not delete items created after the threshold
-	database.CreateRequest(&database.Request{
+	database.CreateRequest(t.Context(), &database.Request{
 		UUID:       "uuid-keep",
 		EndpointID: endpointID,
 		IP:         "test-ip",
@@ -239,6 +239,6 @@ func TestDeleteOldRequests(t *testing.T) {
 		Headers:    datatypes.JSON(`{ "Test": "Test-Header" }`),
 		CreatedAt:  threshold.Add(1 * time.Hour),
 	})
-	database.DeleteOldRequests(threshold)
-	assert.Equal(t, int64(1), database.CountRequests())
+	database.DeleteOldRequests(t.Context(),threshold)
+	assert.Equal(t, int64(1), database.CountRequests(t.Context()))
 }

--- a/src/logging/logging.go
+++ b/src/logging/logging.go
@@ -1,0 +1,106 @@
+// Package logging configures structured logging for httphq.
+//
+// Every log line is a single JSON object written to stdout, using
+// OpenTelemetry attribute names (service.name, deployment.environment, ...) so
+// the output stays portable across log backends. Init wires slog's default
+// logger; request-scoped code passes a context.Context carrying the request
+// ID, which is stamped onto every record for correlation.
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+type ctxKey int
+
+const requestIDKey ctxKey = iota
+
+// WithRequestID returns a copy of ctx carrying id, so any log emitted
+// downstream is correlated to the same request.
+func WithRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, requestIDKey, id)
+}
+
+func requestIDFrom(ctx context.Context) string {
+	id, _ := ctx.Value(requestIDKey).(string)
+	return id
+}
+
+// ctxHandler wraps an slog.Handler and stamps request_id (read from the
+// context) onto every record, so a log call deep inside a handler stays
+// correlated without threading a logger through every signature.
+type ctxHandler struct{ slog.Handler }
+
+func (h ctxHandler) Handle(ctx context.Context, r slog.Record) error {
+	if id := requestIDFrom(ctx); id != "" {
+		r.AddAttrs(slog.String("request_id", id))
+	}
+	return h.Handler.Handle(ctx, r)
+}
+
+func (h ctxHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return ctxHandler{h.Handler.WithAttrs(attrs)}
+}
+
+func (h ctxHandler) WithGroup(name string) slog.Handler {
+	return ctxHandler{h.Handler.WithGroup(name)}
+}
+
+// sensitiveKeys are masked wherever they appear as a log attribute key. Access
+// logs are already built from a fixed, safe field set; this is a backstop
+// against secrets reaching ad-hoc application logs.
+var sensitiveKeys = map[string]struct{}{
+	"authorization": {},
+	"cookie":        {},
+	"set-cookie":    {},
+	"x-api-key":     {},
+	"api_key":       {},
+	"password":      {},
+	"token":         {},
+	"secret":        {},
+}
+
+func replaceAttr(groups []string, a slog.Attr) slog.Attr {
+	// Lower-case the level (INFO -> info) so it matches the other services.
+	if len(groups) == 0 && a.Key == slog.LevelKey {
+		return slog.String(slog.LevelKey, strings.ToLower(a.Value.String()))
+	}
+	if _, ok := sensitiveKeys[strings.ToLower(a.Key)]; ok {
+		return slog.String(a.Key, "[redacted]")
+	}
+	return a
+}
+
+// Init installs the process-wide slog logger: JSON to stdout, an OTel-named
+// service.name/deployment.environment base, request_id stamping and
+// sensitive-key redaction. The level defaults to info in production and debug
+// elsewhere, overridable with LOG_LEVEL (debug|info|warn|error).
+func Init(service, env string) {
+	level := slog.LevelInfo
+	if env != "production" {
+		level = slog.LevelDebug
+	}
+	switch strings.ToLower(os.Getenv("LOG_LEVEL")) {
+	case "debug":
+		level = slog.LevelDebug
+	case "info":
+		level = slog.LevelInfo
+	case "warn":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	}
+
+	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level:       level,
+		ReplaceAttr: replaceAttr,
+	})
+	logger := slog.New(ctxHandler{handler}).With(
+		slog.String("service.name", service),
+		slog.String("deployment.environment", env),
+	)
+	slog.SetDefault(logger)
+}

--- a/src/requestlog.go
+++ b/src/requestlog.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"log/slog"
+	"regexp"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+
+	"httphq/src/logging"
+)
+
+// requestIDPattern bounds an inbound X-Request-Id so an untrusted caller can't
+// inject oversized or high-cardinality values into the logs.
+var requestIDPattern = regexp.MustCompile(`^[A-Za-z0-9-]{8,64}$`)
+
+// probePaths are hit by Kubernetes liveness/readiness probes; their access log
+// drops to debug so probe traffic stays out of production logs.
+var probePaths = map[string]struct{}{
+	"/api/health": {},
+}
+
+// requestLogger assigns each request a correlation ID — reusing a valid
+// inbound X-Request-Id, otherwise minting one — exposes it on the context and
+// the X-Request-Id response header, and emits one structured access-log line.
+// Request headers and bodies are never logged, and the path is logged without
+// its query string.
+func requestLogger(c fiber.Ctx) error {
+	id := c.Get("X-Request-Id")
+	if !requestIDPattern.MatchString(id) {
+		id = uuid.NewString()
+	}
+	c.SetContext(logging.WithRequestID(c.Context(), id))
+	c.Set("X-Request-Id", id)
+
+	start := time.Now()
+	err := c.Next()
+
+	level := slog.LevelInfo
+	if _, isProbe := probePaths[c.Path()]; isProbe {
+		level = slog.LevelDebug
+	}
+	attrs := []slog.Attr{
+		slog.String("http.request.method", c.Method()),
+		slog.String("url.path", c.Path()),
+		slog.Int("http.response.status_code", c.Response().StatusCode()),
+		slog.Float64("http.server.request.duration", time.Since(start).Seconds()),
+	}
+	if err != nil {
+		attrs = append(attrs, slog.String("err", err.Error()))
+		level = slog.LevelError
+	}
+	slog.LogAttrs(c.Context(), level, "request", attrs...)
+	return err
+}


### PR DESCRIPTION
## What

Replaces the unstructured stdlib `log` calls with `log/slog` emitting one JSON object per line to stdout. The app stays backend-agnostic — the decoupling boundary is stdout, so any collector can pick the logs up.

## Changes

- **`src/logging/`** — `slog` JSON setup: OpenTelemetry semantic-convention field names (`service.name`, `http.request.method`, `url.path`, ...), a context-aware handler that stamps `request_id` onto every record, a sensitive-key redaction backstop, and `LOG_LEVEL` gating (default `info` in production, `debug` elsewhere).
- **`src/requestlog.go`** — Fiber access-log middleware. Each request reuses a valid inbound `X-Request-Id` (`^[A-Za-z0-9-]{8,64}$`) or mints a UUID, echoes it on the response header, and emits one structured line. Headers and bodies are never logged; the path is logged without its query string. Kubernetes probe traffic to `/api/health` logs at `debug`.
- **`src/database/`** — `context.Context` threaded through the query functions so a query error correlates to its originating request.
- **`README.md`** — logging section.

## Verification

`go vet` / `go build` / `go test ./...` all pass. Runtime smoke test confirmed JSON output, OTel field names, `request_id` correlation (inbound reuse, regex rejection, response-header echo), and probe hits producing zero lines at `info` level. No new dependencies — `slog` is stdlib and `uuid` was already in use.