### PR TITLE
Run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,12 @@ COPY --from=builder /usr/src/app/bin/httphq ./bin/httphq
 COPY ./public ./public
 COPY ./src/views ./src/views
 
+RUN addgroup -S -g 1001 httphq \
+ && adduser  -S -u 1001 -G httphq httphq \
+ && chown -R httphq:httphq /app
+
+USER httphq
+
 ENV APPLICATION_ENV=production
 
 EXPOSE 8080


### PR DESCRIPTION
## Summary

- Adds a dedicated `httphq` user (UID/GID 1001) to the runner stage of the Dockerfile and chowns `/app` so SQLite can still write `local.db` relative to `WORKDIR`.
- Unblocks deployment under a restricted Kubernetes PodSecurity policy (`securityContext.runAsNonRoot: true`).

Closes the request to run the container as a non-root user.

## Test plan

- [x] `docker build .` succeeds.
- [x] `docker run --rm --user 1001:1001 <image>` starts cleanly, `id` reports `uid=1001(httphq)`, and `/api/health` responds `OK`.