### PR TITLE
Fix endpoint URLs rendering http:// behind the ingress

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
+	github.com/valyala/fasthttp v1.71.0
 	gorm.io/datatypes v1.2.7
 	gorm.io/gorm v1.31.1
 )
@@ -39,7 +40,6 @@ require (
 	github.com/savsgio/gotils v0.0.0-20250924091648-bce9a52d7761 // indirect
 	github.com/tinylib/msgp v1.6.4 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasthttp v1.71.0 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/src/application.go
+++ b/src/application.go
@@ -95,6 +95,33 @@ func resolvePlatform(name string) platformConfig {
 	return platforms["direct"]
 }
 
+// trustedProxyConfig lists the peers whose X-Forwarded-* headers Fiber may
+// honour once TrustProxy is enabled. httphq is only ever fronted by an
+// in-cluster ingress/proxy, which reaches the pod from a private, loopback or
+// link-local address; no legitimate direct client connects from those ranges.
+// Keeping the set to those ranges means a public client that somehow reaches
+// the pod directly still can't spoof the scheme or client IP.
+func trustedProxyConfig() fiber.TrustProxyConfig {
+	return fiber.TrustProxyConfig{
+		Private:   true,
+		Loopback:  true,
+		LinkLocal: true,
+	}
+}
+
+// endpointURLs builds the public capture and live-feed URLs shown on an
+// endpoint page. The WebSocket scheme tracks the request scheme so an HTTPS
+// page always advertises wss:// — a ws:// socket on an HTTPS page is blocked
+// by browsers as mixed content.
+func endpointURLs(scheme, host, endpointID string) (endpointURL, websocketURL string) {
+	websocketScheme := "ws"
+	if scheme == "https" {
+		websocketScheme = "wss"
+	}
+	return scheme + "://" + host + "/to/" + endpointID,
+		websocketScheme + "://" + host + "/ws/" + endpointID
+}
+
 // omitHeader reports whether a captured-request header is infrastructure noise
 // — a generic forwarding header or a vendor header added by the configured
 // PLATFORM — and so should be hidden from the user.
@@ -269,8 +296,18 @@ func main() {
 		// c.Scheme() honours X-Forwarded-Proto (correct ws/wss + EndpointURL).
 		// With no platform, the app is treated as directly exposed and
 		// c.IP()/c.Scheme() reflect the real connection.
-		TrustProxy:  currentPlatform.ipHeader != "",
-		ProxyHeader: fiber.HeaderXForwardedFor,
+		//
+		// In Fiber v3, TrustProxy only *enables the check* — X-Forwarded-* is
+		// honoured solely for a peer that TrustProxyConfig recognises, so
+		// TrustProxy on its own trusts no one and c.Scheme() falls back to the
+		// raw (http) connection. httphq always sits behind an in-cluster
+		// ingress/proxy reachable on a private, loopback or link-local address
+		// (e.g. Traefik on the pod network), so trust those ranges. The
+		// default-deny NetworkPolicy keeps the pod unreachable except through
+		// that proxy, so a direct peer can't reach here to spoof the header.
+		TrustProxy:       currentPlatform.ipHeader != "",
+		TrustProxyConfig: trustedProxyConfig(),
+		ProxyHeader:      fiber.HeaderXForwardedFor,
 	})
 
 	// Runs first so every request — including rate-limited ones — gets a
@@ -412,16 +449,12 @@ func main() {
 			return c.SendStatus(http.StatusNotFound)
 		}
 		host := string(c.Request().Host())
-		scheme := c.Scheme()
-		websocketScheme := "ws"
-		if scheme == "https" {
-			websocketScheme = "wss"
-		}
+		endpointURL, websocketURL := endpointURLs(c.Scheme(), host, endpointID)
 		return c.Render("endpoint", fiber.Map{
 			"Title":                endpointID + " | httphq",
 			"EndpointID":           endpointID,
-			"EndpointURL":          scheme + "://" + host + "/to/" + endpointID,
-			"EndpointWebSocketURL": websocketScheme + "://" + host + "/ws/" + endpointID,
+			"EndpointURL":          endpointURL,
+			"EndpointWebSocketURL": websocketURL,
 		})
 	})
 

--- a/src/application_test.go
+++ b/src/application_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+// schemeFor spins up a request from peerIP carrying the given
+// X-Forwarded-Proto (empty = header absent) and returns the scheme Fiber
+// resolves for it. The connection itself is plain HTTP, so anything other
+// than "http" means the forwarded header was trusted and honoured.
+func schemeFor(t *testing.T, app *fiber.App, peerIP, forwardedProto string) string {
+	t.Helper()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP(peerIP)})
+
+	c := app.AcquireCtx(fctx)
+	defer app.ReleaseCtx(c)
+
+	if forwardedProto != "" {
+		c.Request().Header.Set(fiber.HeaderXForwardedProto, forwardedProto)
+	}
+	return c.Scheme()
+}
+
+// proxyTrustApp mirrors the production Fiber config for a request that
+// arrives with a PLATFORM configured (TrustProxy enabled): the app trusts
+// the forwarding proxy on the ranges from trustedProxyConfig.
+func proxyTrustApp() *fiber.App {
+	return fiber.New(fiber.Config{
+		TrustProxy:       true,
+		TrustProxyConfig: trustedProxyConfig(),
+	})
+}
+
+func TestEndpointURLs(t *testing.T) {
+	cases := []struct {
+		name        string
+		scheme      string
+		wantEndURL  string
+		wantSockURL string
+	}{
+		{
+			name:        "https yields wss",
+			scheme:      "https",
+			wantEndURL:  "https://httphq.com/to/purple-frog-0691",
+			wantSockURL: "wss://httphq.com/ws/purple-frog-0691",
+		},
+		{
+			name:        "http yields ws",
+			scheme:      "http",
+			wantEndURL:  "http://httphq.com/to/purple-frog-0691",
+			wantSockURL: "ws://httphq.com/ws/purple-frog-0691",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			endURL, sockURL := endpointURLs(tc.scheme, "httphq.com", "purple-frog-0691")
+			assert.Equal(t, tc.wantEndURL, endURL)
+			assert.Equal(t, tc.wantSockURL, sockURL)
+		})
+	}
+}
+
+// TestSchemeHonorsForwardedProtoFromTrustedProxy is the regression guard for
+// the http:// endpoint-URL bug. With TrustProxy enabled and an in-cluster
+// proxy peer (Traefik on the pod network, or loopback for a sidecar), the
+// app must honour X-Forwarded-Proto: https and report the https scheme —
+// otherwise EndpointURL renders http:// and the live feed renders ws://.
+func TestSchemeHonorsForwardedProtoFromTrustedProxy(t *testing.T) {
+	app := proxyTrustApp()
+
+	// One address from each range trustedProxyConfig covers.
+	peers := map[string]string{
+		"k3s pod network (private 10/8)": "10.42.0.212",
+		"private 172.16/12":              "172.16.5.4",
+		"private 192.168/16":             "192.168.1.10",
+		"loopback (sidecar)":             "127.0.0.1",
+		"link-local":                     "169.254.10.20",
+	}
+
+	for name, ip := range peers {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, "https", schemeFor(t, app, ip, "https"),
+				"trusted proxy %s should have its X-Forwarded-Proto honoured", ip)
+		})
+	}
+}
+
+// TestSchemeIgnoresForwardedProtoFromUntrustedPeer proves the trust is
+// bounded: a public-range peer that reaches the pod directly cannot spoof
+// the scheme (nor, by the same check, the client IP).
+func TestSchemeIgnoresForwardedProtoFromUntrustedPeer(t *testing.T) {
+	app := proxyTrustApp()
+
+	assert.Equal(t, "http", schemeFor(t, app, "203.0.113.7", "https"),
+		"a public peer must not be able to forge X-Forwarded-Proto")
+}
+
+// TestSchemeDirectModeIgnoresForwardedProto guards the direct-deployment
+// security property: with no PLATFORM configured TrustProxy is off, so the
+// app reports the real connection scheme even for a private-range peer and
+// never trusts a forwarded header.
+func TestSchemeDirectModeIgnoresForwardedProto(t *testing.T) {
+	direct := fiber.New(fiber.Config{
+		TrustProxy:       false,
+		TrustProxyConfig: trustedProxyConfig(),
+	})
+
+	assert.Equal(t, "http", schemeFor(t, direct, "10.42.0.212", "https"),
+		"direct mode must ignore X-Forwarded-Proto entirely")
+}
+
+// TestResolvePlatformGatesProxyTrust documents the link between PLATFORM and
+// proxy trust: TrustProxy is `ipHeader != ""`, so proxy-fronted platforms
+// enable trust while an empty or unknown value fails safe to direct (no
+// trust). A regression here silently re-breaks the scheme in either
+// direction.
+func TestResolvePlatformGatesProxyTrust(t *testing.T) {
+	trusts := []string{"proxy", "cloudflare", "fly", "heroku", "render"}
+	for _, name := range trusts {
+		assert.NotEmpty(t, resolvePlatform(name).ipHeader,
+			"%s should enable proxy trust", name)
+	}
+
+	noTrust := []string{"", "direct", "not-a-platform"}
+	for _, name := range noTrust {
+		assert.Empty(t, resolvePlatform(name).ipHeader,
+			"%q should fall back to direct (no proxy trust)", name)
+	}
+}


### PR DESCRIPTION
Endpoint pages built their capture and live-feed URLs from the request scheme, which reported `http` even when the request was forwarded over HTTPS by a fronting reverse proxy. URLs rendered as `http://` and `ws://`, and the `ws://` live feed was blocked as mixed content on an HTTPS page.

Fiber v3 honours `X-Forwarded-*` only for a peer listed in `TrustProxyConfig`, which was not set. This adds a `TrustProxyConfig` trusting private, loopback and link-local ranges, so the app reports the forwarded scheme and the URLs use `https://` and `wss://`.

Extracts `endpointURLs()` and `trustedProxyConfig()` and adds tests covering scheme resolution and URL derivation.