### PR TITLE
Add copy-as-HAR buttons for captured requests

### DIFF
--- a/e2e/tests/endpoint-screen.spec.ts
+++ b/e2e/tests/endpoint-screen.spec.ts
@@ -249,6 +249,114 @@ test.describe("Endpoint screen", () => {
       expect(parsed["X-Sample"]).toBe("value");
     });
 
+    test("request copy button writes a HAR-shaped document to the clipboard", async ({
+      page,
+      request,
+    }) => {
+      const raw = '{"hello":"world"}';
+      const response = await request.post(`${endpointUrl}?a=1&b=2`, {
+        data: raw,
+        headers: { "Content-Type": "application/json", "X-Sample": "value" },
+      });
+      const uuid = response.headers()["httphq-request-uuid"];
+      const card = page.locator(`#request-${uuid}`);
+      await expect(card).toBeAttached();
+
+      await card.locator('[data-test="copy-request-har"]').click();
+      const clipboard = await page.evaluate(() =>
+        navigator.clipboard.readText(),
+      );
+      const har = JSON.parse(clipboard);
+
+      expect(har.creator.name).toBe("httphq");
+      expect(har.entries).toHaveLength(1);
+      const entry = har.entries[0];
+      expect(entry.id).toBe(uuid);
+      expect(entry.request.method).toBe("POST");
+      expect(entry.request.url).toBe(`${endpointUrl}?a=1&b=2`);
+      expect(entry.request.httpVersion).toBe("HTTP/1.1");
+      expect(entry.request.queryString).toEqual([
+        { name: "a", value: "1" },
+        { name: "b", value: "2" },
+      ]);
+      expect(entry.request.headers).toContainEqual({
+        name: "X-Sample",
+        value: "value",
+      });
+      expect(entry.request.postData).toEqual({
+        mimeType: "application/json",
+        text: raw,
+      });
+      expect(entry.request.bodySize).toBe(raw.length);
+    });
+
+    test("request copy button label flips to Copied!", async ({
+      page,
+      request,
+    }) => {
+      await post(request, endpointUrl, { data: "x" });
+      const card = page.locator('[data-test="request"]').first();
+      await card.locator('[data-test="copy-request-har"]').click();
+      await expect(
+        card.locator('[data-test="copy-request-har-label"]'),
+      ).toContainText("Copied!");
+    });
+
+    test("copy-all writes every visible request, newest first", async ({
+      page,
+      request,
+    }) => {
+      await post(request, endpointUrl, { data: "first" });
+      await expect(page.locator('[data-test="request"]')).toHaveCount(1);
+      await post(request, endpointUrl, { data: "second" });
+      await expect(page.locator('[data-test="request"]')).toHaveCount(2);
+
+      await page.locator('[data-test="copy-all-har"]').click();
+      const clipboard = await page.evaluate(() =>
+        navigator.clipboard.readText(),
+      );
+      const har = JSON.parse(clipboard);
+
+      expect(har.entries).toHaveLength(2);
+      expect(
+        har.entries.map(
+          (e: { request: { postData: { text: string } } }) =>
+            e.request.postData.text,
+        ),
+      ).toEqual(["second", "first"]);
+    });
+
+    test("copy-all is scoped to the method filter", async ({
+      page,
+      request,
+    }) => {
+      await post(request, endpointUrl, { data: "p" });
+      await request.fetch(endpointUrl, { method: "PUT", data: "u" });
+      await expect(page.locator('[data-test="search-results"]')).toContainText(
+        "2 results",
+      );
+
+      await page.locator('[data-test="method-filter"]').selectOption("PUT");
+      await expect(
+        page.locator('[data-test="copy-all-har-label"]'),
+      ).toContainText("Copy all (1)");
+
+      await page.locator('[data-test="copy-all-har"]').click();
+      const clipboard = await page.evaluate(() =>
+        navigator.clipboard.readText(),
+      );
+      const har = JSON.parse(clipboard);
+
+      expect(har.entries).toHaveLength(1);
+      expect(har.entries[0].request.method).toBe("PUT");
+    });
+
+    test("copy-all is disabled while nothing has been captured", async ({
+      page,
+    }) => {
+      await expect(page.locator('[data-test="copy-all-har"]')).toBeDisabled();
+    });
+
     test("filters by request body via the search box", async ({
       page,
       request,

--- a/public/endpoint.js
+++ b/public/endpoint.js
@@ -94,6 +94,7 @@
       sendForm: { method: "POST", body: "", headers: "" },
       sendStatus: "",
       copyLabel: "Copy",
+      copiedKey: null,
       _baseTitle: document.title,
       _unread: 0,
 
@@ -166,6 +167,21 @@
           await window.copyToClipboard(text);
           this.copyLabel = "Copied!";
           setTimeout(() => (this.copyLabel = "Copy"), 1500);
+        } catch (err) {
+          console.error(err);
+        }
+      },
+
+      // Copies requests as a HAR-shaped document. `key` names the button that
+      // should read "Copied!" — several buttons share this one component
+      // instance, so a single label field can't tell them apart.
+      async copyHar(requests, key) {
+        try {
+          await window.copyToClipboard(window.buildHarExport(requests));
+          this.copiedKey = key;
+          setTimeout(() => {
+            if (this.copiedKey === key) this.copiedKey = null;
+          }, 1500);
         } catch (err) {
           console.error(err);
         }

--- a/public/har.js
+++ b/public/har.js
@@ -1,0 +1,92 @@
+/* Serialises captured requests to a HAR-shaped JSON document for the clipboard.
+
+   The field names and value shapes follow HAR 1.2 so the output is familiar to
+   HAR tooling, but entries carry only a `request`: httphq never observes a
+   response, so `response`, `timings` and `cache` are omitted rather than
+   emitted as stubs that would read as captured data. Loaded on every page. */
+
+(function () {
+  const CREATOR = { name: "httphq", version: "1" };
+
+  // Not captured: the capture handler never records the protocol, so every
+  // entry claims HTTP/1.1. Revisit if the request model starts storing it.
+  const ASSUMED_HTTP_VERSION = "HTTP/1.1";
+
+  /* Absolute URL for a captured request. `path` already carries the
+     /to/<endpoint> prefix; the scheme comes from the page because it is not
+     stored, and the Host header is preferred over the page's so a request
+     captured through another hostname still round-trips. */
+  function entryURL(request) {
+    const host = window.headerValue(request.headers, "Host") || location.host;
+    const query = request.queryString ? `?${request.queryString}` : "";
+    return `${location.protocol}//${host}${request.path}${query}`;
+  }
+
+  /* HAR represents a repeated header as one entry per value, so the stored
+     scalar-or-array value is expanded rather than joined.
+
+     Order is alphabetical, not wire order: the capture handler flattens
+     headers through a Go map and encoding/json sorts keys on marshal. Nothing
+     downstream may treat this ordering as meaningful. */
+  function entryHeaders(headers) {
+    const out = [];
+    for (const [name, value] of Object.entries(headers || {})) {
+      for (const one of Array.isArray(value) ? value : [value]) {
+        out.push({ name, value: String(one) });
+      }
+    }
+    return out;
+  }
+
+  function entryQueryString(queryString) {
+    if (!queryString) return [];
+    return [...new URLSearchParams(queryString)].map(([name, value]) => ({
+      name,
+      value,
+    }));
+  }
+
+  function harEntry(request) {
+    const body = request.body || "";
+    // Omitted entirely for bodyless requests, matching HAR, where postData is
+    // absent rather than empty when there was no payload.
+    const postData = body
+      ? {
+          mimeType: window.headerValue(request.headers, "Content-Type") || "",
+          // Verbatim, never base64: the body carries the same U+FFFD
+          // substitutions the request panel displays.
+          text: body,
+        }
+      : null;
+
+    return {
+      id: request.uuid,
+      startedDateTime: new Date(request.createdAt).toISOString(),
+      clientIPAddress: request.ip,
+      request: {
+        method: request.method,
+        url: entryURL(request),
+        httpVersion: ASSUMED_HTTP_VERSION,
+        headers: entryHeaders(request.headers),
+        queryString: entryQueryString(request.queryString),
+        ...(postData ? { postData } : {}),
+        // Byte length of the captured body, which httphq stores as a Go
+        // string — encoding/json replaces invalid UTF-8 with U+FFFD on
+        // marshal, so for genuinely binary uploads this can differ from the
+        // true original size. See database.Request.Body.
+        bodySize: new TextEncoder().encode(body).length,
+      },
+    };
+  }
+
+  /* Takes captured requests in display order (newest first) and returns the
+     document as pretty-printed JSON. A single request and the whole list share
+     one envelope, so consumers parse the same shape either way. */
+  window.buildHarExport = function (requests) {
+    return JSON.stringify(
+      { creator: CREATOR, entries: (requests || []).map(harEntry) },
+      null,
+      2,
+    );
+  };
+})();

--- a/public/render-body.js
+++ b/public/render-body.js
@@ -20,7 +20,9 @@ function highlightPrettyJSON(value) {
 }
 
 /* Case-insensitive lookup into a headers object whose values are either a
-   scalar string or a string[] (see the flattening in application.go). */
+   scalar string or a string[] (see the flattening in application.go). Exposed
+   as window.headerValue because that scalar-or-array contract is shared by
+   every consumer of a captured request, not just body rendering. */
 function headerValue(headers, name) {
   if (!headers) return undefined;
   const key = Object.keys(headers).find(
@@ -141,3 +143,5 @@ window.renderBody = function (body, headers) {
   }
   return htmlEscape(body);
 };
+
+window.headerValue = headerValue;

--- a/src/views/endpoint.html
+++ b/src/views/endpoint.html
@@ -146,27 +146,55 @@
       <span aria-hidden="true">⚠️</span>
       <span>Requests are deleted after 4 hours</span>
     </p>
-    <button
-      type="button"
-      data-test="delete-requests"
-      @click="$store.main.deleteRequests()"
-      class="inline-flex items-center gap-1.5 rounded-md border border-rose-200 bg-rose-50 px-3 py-1.5 text-sm font-medium text-rose-700 hover:bg-rose-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500"
-    >
-      <svg
-        viewBox="0 0 24 24"
-        class="w-4 h-4"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        aria-hidden="true"
+    <div class="flex items-center gap-2">
+      <button
+        type="button"
+        data-test="copy-all-har"
+        @click="copyHar($store.main.visibleRequests, '__all__')"
+        :disabled="$store.main.visibleRequests.length === 0"
+        title="Copy every request shown as HAR-shaped JSON"
+        class="inline-flex items-center gap-1.5 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        <polyline points="3 6 5 6 21 6" />
-        <path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6" />
-        <path d="M10 11v6" />
-        <path d="M14 11v6" />
-      </svg>
-      Delete all
-    </button>
+        <svg
+          viewBox="0 0 24 24"
+          class="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <rect x="9" y="2" width="6" height="4" rx="1" />
+          <path
+            d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
+          />
+        </svg>
+        <span
+          data-test="copy-all-har-label"
+          x-text="copiedKey === '__all__' ? 'Copied!' : `Copy all (${$store.main.visibleRequests.length})`"
+        ></span>
+      </button>
+      <button
+        type="button"
+        data-test="delete-requests"
+        @click="$store.main.deleteRequests()"
+        class="inline-flex items-center gap-1.5 rounded-md border border-rose-200 bg-rose-50 px-3 py-1.5 text-sm font-medium text-rose-700 hover:bg-rose-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          class="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <polyline points="3 6 5 6 21 6" />
+          <path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6" />
+          <path d="M10 11v6" />
+          <path d="M14 11v6" />
+        </svg>
+        Delete all
+      </button>
+    </div>
   </div>
 
   <!-- Filter bar -->
@@ -243,26 +271,55 @@
               class="text-xs text-slate-500 font-mono truncate hover:text-indigo-600"
             ></a>
           </div>
-          <button
-            type="button"
-            data-test="delete-request"
-            @click="$store.main.deleteRequest(request.uuid)"
-            class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-rose-600"
-            aria-label="Delete this request"
-          >
-            <svg
-              viewBox="0 0 24 24"
-              class="w-4 h-4"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              aria-hidden="true"
+          <div class="flex items-center gap-3 shrink-0">
+            <button
+              type="button"
+              data-test="copy-request-har"
+              @click="copyHar([request], request.uuid)"
+              aria-label="Copy this request as JSON"
+              title="Copy the full request (method, URL, headers, query string, body) as HAR-shaped JSON"
+              class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-indigo-600"
             >
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-            <span class="hidden sm:inline">Delete</span>
-          </button>
+              <svg
+                viewBox="0 0 24 24"
+                class="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                aria-hidden="true"
+              >
+                <rect x="9" y="2" width="6" height="4" rx="1" />
+                <path
+                  d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
+                />
+              </svg>
+              <span
+                data-test="copy-request-har-label"
+                class="hidden sm:inline"
+                x-text="copiedKey === request.uuid ? 'Copied!' : 'Copy request'"
+              ></span>
+            </button>
+            <button
+              type="button"
+              data-test="delete-request"
+              @click="$store.main.deleteRequest(request.uuid)"
+              class="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-rose-600"
+              aria-label="Delete this request"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                class="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                aria-hidden="true"
+              >
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+              <span class="hidden sm:inline">Delete</span>
+            </button>
+          </div>
         </header>
 
         <div class="space-y-4 p-4 sm:p-5">

--- a/src/views/layouts/main.html
+++ b/src/views/layouts/main.html
@@ -37,6 +37,7 @@
          queueMicrotask at the end of its own script execution. -->
     <script defer src="/index.js"></script>
     <script defer src="/render-body.js"></script>
+    <script defer src="/har.js"></script>
     <script defer src="/endpoint.js"></script>
 
     <!-- Alpine.js (loaded last so app scripts can subscribe first). -->


### PR DESCRIPTION
## What

Adds two clipboard actions on the endpoint screen:

- **Copy request** — per card, next to Delete.
- **Copy all (N)** — page level, next to Delete all.

Both put a HAR-shaped JSON document on the clipboard containing everything about the request: method, URL, headers, query string and body. Same envelope either way, so consumers parse one shape regardless of which button was used.

```json
{
  "creator": { "name": "httphq", "version": "1" },
  "entries": [
    {
      "id": "0625b960-0143-4163-99cb-72484269ab09",
      "startedDateTime": "2026-08-08T08:55:00.809Z",
      "clientIPAddress": "127.0.0.1",
      "request": {
        "method": "GET",
        "url": "http://localhost:8080/to/demo-har-panel?utm_source=newsletter&plan=pro",
        "httpVersion": "HTTP/1.1",
        "headers": [{ "name": "X-Api-Key", "value": "sk_test_123" }],
        "queryString": [{ "name": "utm_source", "value": "newsletter" }],
        "bodySize": 0
      }
    }
  ]
}
```

## Notes

- **Request-only, by design.** Field names and shapes follow HAR 1.2 so the output is familiar to HAR tooling, but httphq never observes a response — `response`, `timings` and `cache` are omitted rather than emitted as stubs that would read as captured data.
- **Global button is scoped to what's visible.** It copies `visibleRequests`, so the method filter and search box double as a way to scope the export. The count in the label makes that scope visible; it's disabled at zero.
- **The existing headers/body copy links stay.** This is additive.
- **Frontend only** — no API, schema or Go changes. Everything needed is already in the client-side store.

Two properties worth knowing, both commented in `public/har.js`:

- `httpVersion` is hardcoded to `HTTP/1.1`; the capture handler never records the protocol. Capturing it for real would need a new column on `database.Request` — separate change if it's wanted.
- Header order is alphabetical, not wire order, because the capture handler flattens headers through a Go map and `encoding/json` sorts keys on marshal.

## Testing

- `go test ./...` passes (unaffected — no Go changes).
- Playwright: 35/35 pass, including 5 new tests covering the per-card payload shape, the `Copied!` feedback, copy-all ordering (newest first), filter scoping, and the disabled-when-empty state.
- Verified by hand in the browser against live captured GET/POST/PUT traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXy9D2BfSUqqj7BjPWs3fv