### PR TITLE
Version static asset URLs by content hash

### DIFF
--- a/src/application.go
+++ b/src/application.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -123,6 +126,69 @@ func buildContentSecurityPolicy() string {
 		"img-src 'self' data:; " +
 		"connect-src 'self' ws: wss:" + designTooling + "; " +
 		"frame-ancestors 'none'"
+}
+
+// assetVersions maps a served static path to a short hash of its contents,
+// computed once at startup. The stylesheet and the page scripts live at fixed
+// paths, so without a version in the URL a CDN or a browser can pair a cached
+// copy of one deploy with the HTML of the next: every class name the new markup
+// asks for resolves to nothing and the page renders unstyled. Versioning the URL
+// makes a changed asset a different URL, which no cache can confuse for the old
+// one.
+var assetVersions = map[string]string{}
+
+// versionedAssets are the first-party files referenced from the templates whose
+// contents change between deploys. Images are excluded: they are replaced rarely
+// and never in a way that breaks a page that fetched the previous copy.
+var versionedAssets = []string{
+	"/app.css",
+	"/index.js",
+	"/render-body.js",
+	"/har.js",
+	"/endpoint.js",
+}
+
+func hashAsset(path string) string {
+	f, err := os.Open("./public" + path)
+	if err != nil {
+		slog.Warn("asset missing, serving unversioned", "path", path, "err", err)
+		return ""
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		slog.Warn("asset unreadable, serving unversioned", "path", path, "err", err)
+		return ""
+	}
+	return hex.EncodeToString(h.Sum(nil))[:10]
+}
+
+// assetURL is exposed to templates as `asset`. Production reads the map computed
+// at startup. Development re-hashes, but only when the file's modification time
+// has moved, so an edited stylesheet is picked up without a restart and without
+// re-reading every asset on every render.
+var assetMu sync.Mutex
+var assetStamps = map[string]time.Time{}
+
+func assetURL(path string) string {
+	if isProduction {
+		if version := assetVersions[path]; version != "" {
+			return path + "?v=" + version
+		}
+		return path
+	}
+
+	assetMu.Lock()
+	defer assetMu.Unlock()
+	info, err := os.Stat("./public" + path)
+	if err == nil && !info.ModTime().Equal(assetStamps[path]) {
+		assetStamps[path] = info.ModTime()
+		assetVersions[path] = hashAsset(path)
+	}
+	if version := assetVersions[path]; version != "" {
+		return path + "?v=" + version
+	}
+	return path
 }
 
 // trustedProxyConfig lists the peers whose X-Forwarded-* headers Fiber may
@@ -320,6 +386,11 @@ func main() {
 	/* Server */
 
 	engine := html.New("./src/views", ".html")
+
+	for _, path := range versionedAssets {
+		assetVersions[path] = hashAsset(path)
+	}
+	engine.AddFunc("asset", assetURL)
 
 	if !isProduction {
 		engine.Reload(true)

--- a/src/views/layouts/main.html
+++ b/src/views/layouts/main.html
@@ -38,7 +38,7 @@
     <!-- Built from src/styles/app.css by `npm run css`. The only stylesheet on
          the marketing and contact pages, and the only render-blocking resource
          anywhere: no page waits on a third party to have a layout. -->
-    <link rel="stylesheet" href="/app.css" />
+    <link rel="stylesheet" href="{{asset `/app.css`}}" />
 
     {{if .AppScripts}}
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
@@ -61,10 +61,10 @@
     <!-- App scripts must register their alpine:init listeners BEFORE Alpine
          loads, because Alpine v3 schedules its first alpine:init dispatch via
          queueMicrotask at the end of its own script execution. -->
-    <script defer src="/index.js"></script>
-    <script defer src="/render-body.js"></script>
-    <script defer src="/har.js"></script>
-    <script defer src="/endpoint.js"></script>
+    <script defer src="{{asset `/index.js`}}"></script>
+    <script defer src="{{asset `/render-body.js`}}"></script>
+    <script defer src="{{asset `/har.js`}}"></script>
+    <script defer src="{{asset `/endpoint.js`}}"></script>
 
     <!-- Alpine.js (loaded last so app scripts can subscribe first). -->
     <script


### PR DESCRIPTION
**Production is currently rendering unstyled.** This fixes it and stops it recurring.

## What happened

Replacing the Tailwind CDN with a first-party stylesheet put the CSS at a fixed URL, `/app.css`, with no fingerprint. When the colour rework shipped, Cloudflare kept serving the previous stylesheet for its full `max-age=14400` lifetime while the origin served the new HTML.

Measured on production while diagnosing:

```
/app.css  →  31,480 bytes, contains .text-slate-500 and .bg-indigo-600
             cf-cache-status: HIT, age: 4808, cache-control: max-age=14400
```

That is the pre-rework vocabulary. The new markup asks for `text-neutral-500`, `bg-brand-600`, `bg-get-wash` — none of which exist in the cached file — so every colour resolves to nothing. Borders come out black because `border-color` falls back to `currentColor` when its rule is missing, which is why it looked like a rendering bug rather than a caching one.

The HTML itself is `cf-cache-status: DYNAMIC`, so deploying this fixes production immediately: the new markup points at a URL the edge has never seen. No purge needed.

## The fix

Every first-party asset the templates reference carries a short content hash in its URL:

```
/app.css?v=21de7008dc
/index.js?v=3180e57ef8   /render-body.js?v=f0a4431e4d
/har.js?v=6634e21ce3     /endpoint.js?v=c140a7e6dc
```

A changed file is a different URL, so no cache can pair it with the wrong HTML. Images are excluded: they are replaced rarely and never in a way that breaks a page holding the previous copy.

Hashes are computed once at startup. Development re-hashes on demand so an edited stylesheet needs no restart.

## One thing worth flagging

The first implementation re-hashed all five files on **every render** in development. That made template rendering the bottleneck under parallel load: the e2e suite went from 4 seconds to 32 and started failing tests intermittently. I nearly wrote that off as flake — it reproduced as "first run after a server start is slow and loses 3-4 tests, subsequent runs are green".

Keying the dev re-hash on modification time fixed it: **3.5s and 39/39 on the cold run**, three consecutive clean full runs.

Template strings use backquotes rather than nested double quotes, so the layout stays parseable as HTML — Prettier caught that the first form was malformed even though Go's template engine handled it.

## Verification

`go vet`, `gofmt`, `go build`, unit tests, `prettier --check .` clean. Playwright 39/39 across three consecutive runs. Verified the rendered URLs resolve and that the hash tracks file contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8JeP7AQwpd2coSfwbMopt