### PR TITLE
Sweep at boot, and stop rendering swept captures

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -92,7 +92,8 @@ Confirmed functionality:
 
 Technical constraints:
 
-- Retention is 4 hours; a cron sweep runs every 5 minutes.
+- Retention is 4 hours; a sweep runs at startup and every 5 minutes after. An
+  open page drops captures from its own list as they age out.
 - Storage is SQLite on the container's writable layer. Capture history is lost
   on restart, by design. No durable store, no migration path.
 - Request body limit is 1 MiB.

--- a/public/endpoint.js
+++ b/public/endpoint.js
@@ -117,6 +117,23 @@
           })
           .catch((err) => console.error(err));
       },
+
+      // Nothing tells the page that the server swept a capture out from under
+      // it, so a list left open long enough renders requests that no longer
+      // exist, next to the promise that they were deleted. Dropping them
+      // locally is only the immediate half: the list is windowed, so the
+      // refetch is what resyncs `total` and pulls any older-but-live capture
+      // into the window.
+      pruneExpired(retentionMs) {
+        if (!retentionMs) return;
+        const cutoff = Date.now() - retentionMs;
+        const live = this.requests.filter(
+          (r) => r.createdAt.getTime() > cutoff,
+        );
+        if (live.length === this.requests.length) return;
+        this.requests = live;
+        return this.fetchRequests();
+      },
     });
   });
 
@@ -154,9 +171,19 @@
         if (!endpointId) return;
         const scheme = location.protocol === "https:" ? "wss:" : "ws:";
         this._wsUrl = `${scheme}//${location.host}/ws/${endpointId}`;
+        // A page served without the window keeps every capture it was given
+        // rather than expiring them against a guess.
+        const retentionSeconds = Number(this.$el.dataset.retentionSeconds);
+        this._retentionMs =
+          Number.isFinite(retentionSeconds) && retentionSeconds > 0
+            ? retentionSeconds * 1000
+            : 0;
         Alpine.store("main").setEndpoint(endpointId);
         this._connectWebSocket();
-        setInterval(() => this.tick++, TICK_MS);
+        setInterval(() => {
+          this.tick++;
+          Alpine.store("main").pruneExpired(this._retentionMs);
+        }, TICK_MS);
         document.addEventListener("visibilitychange", () => {
           if (!document.hidden) this._clearUnread();
         });

--- a/src/application.go
+++ b/src/application.go
@@ -122,14 +122,23 @@ func newApplication(config applicationConfig) *fiber.App {
 	return application
 }
 
-// startRetentionSweep drops captures older than the retention window on a
-// schedule. It returns the stopped-on-exit scheduler so the caller owns its
-// lifetime.
+// sweepRetention drops every capture older than the retention window.
+func sweepRetention() {
+	database.DeleteOldRequests(context.Background(), time.Now().Add(-retentionWindow))
+}
+
+// startRetentionSweep sweeps once and then on a schedule. The returned
+// scheduler runs for the life of the process; there is no shutdown path that
+// stops it.
+//
+// The sweep at startup is what makes the window hold: cron's first tick is a
+// full interval away, so a process that restarts more often than the interval
+// would otherwise never sweep at all and captures would outlive the window for
+// as long as the database file does.
 func startRetentionSweep() *cron.Cron {
+	sweepRetention()
 	scheduler := cron.New()
-	if _, err := scheduler.AddFunc(retentionSweep, func() {
-		database.DeleteOldRequests(context.Background(), time.Now().Add(-retentionWindow))
-	}); err != nil {
+	if _, err := scheduler.AddFunc(retentionSweep, sweepRetention); err != nil {
 		slog.Error("cron job registration failed", "err", err)
 		os.Exit(1)
 	}

--- a/src/application_test.go
+++ b/src/application_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"httphq/src/database"
+)
+
+// storeCapture writes a capture for an endpoint at a chosen age. GORM only
+// stamps CreatedAt when it is zero, so passing one keeps it.
+func storeCapture(t *testing.T, endpointID, uuid string, createdAt time.Time) {
+	t.Helper()
+	database.CreateRequest(t.Context(), &database.Request{
+		UUID:       uuid,
+		EndpointID: endpointID,
+		Method:     "POST",
+		Path:       "/",
+		CreatedAt:  createdAt,
+	})
+}
+
+func uuidsFor(ctx context.Context, endpointID string) []string {
+	var uuids []string
+	for _, request := range database.GetRequestsForEndpointID(ctx, endpointID, "", 10) {
+		uuids = append(uuids, request.UUID)
+	}
+	return uuids
+}
+
+func TestSweepRetention(t *testing.T) {
+	t.Run("drops captures older than the retention window", func(t *testing.T) {
+		endpointID := "sweep-old"
+		storeCapture(t, endpointID, "sweep-old-expired",
+			time.Now().Add(-retentionWindow).Add(-time.Minute))
+
+		sweepRetention()
+
+		assert.Empty(t, uuidsFor(t.Context(), endpointID))
+	})
+
+	t.Run("keeps captures inside the retention window", func(t *testing.T) {
+		endpointID := "sweep-recent"
+		storeCapture(t, endpointID, "sweep-recent-live",
+			time.Now().Add(-retentionWindow).Add(time.Minute))
+
+		sweepRetention()
+
+		assert.Equal(t, []string{"sweep-recent-live"}, uuidsFor(t.Context(), endpointID))
+	})
+}

--- a/src/pages.go
+++ b/src/pages.go
@@ -59,6 +59,9 @@ func renderEndpoint(c fiber.Ctx) error {
 		"EndpointID":           endpointID,
 		"EndpointURL":          endpointURL,
 		"EndpointWebSocketURL": websocketURL,
+		// The page drops captures from its own list once they age out, so it
+		// needs the window as a number rather than as the prose it renders.
+		"RetentionSeconds": int(retentionWindow.Seconds()),
 	})
 }
 

--- a/src/routes_test.go
+++ b/src/routes_test.go
@@ -178,6 +178,15 @@ func TestPageRoutes(t *testing.T) {
 		assert.Contains(t, body, "endpoint.js?v=")
 	})
 
+	// The page expires captures out of its own list, so it needs the window as
+	// a number. Rendering it from the same constant the sweep uses is what keeps
+	// the two from drifting.
+	t.Run("an endpoint page carries the retention window", func(t *testing.T) {
+		body := bodyOf(t, get(t, "/"+endpointID(t)))
+
+		assert.Contains(t, body, `data-retention-seconds="14400"`)
+	})
+
 	// robots.txt excludes endpoint pages, so a canonical URL pointing them at a
 	// shared address would be a claim nothing else in the site makes.
 	t.Run("an endpoint page carries no canonical URL", func(t *testing.T) {

--- a/src/views/endpoint.html
+++ b/src/views/endpoint.html
@@ -4,6 +4,7 @@
   class="flex-1 pb-12"
   x-data="endpointPage"
   data-endpoint-id="{{.EndpointID}}"
+  data-retention-seconds="{{.RetentionSeconds}}"
 >
   <h1 class="sr-only">Captured requests for {{.EndpointID}}</h1>
 


### PR DESCRIPTION
Captured requests are deleted after 4 hours. That window is stated on the landing page, on every endpoint page, and in the endpoint page description. Two things let reality drift from it.

## The sweep never ran at boot

`startRetentionSweep` registered `*/5 * * * *` with cron and nothing else. Cron's first tick is a full interval away, so a process restarted more often than every 5 minutes never swept at all. Deploys, crash loops, or a platform that recycles the container left captures alive past the window for as long as the database file survived.

The sweep body is now a named `sweepRetention`, called once before the scheduler starts.

Also corrected the doc comment on `startRetentionSweep`, which claimed to return "the stopped-on-exit scheduler so the caller owns its lifetime" while `main()` discards the return value and no shutdown path calls `Stop()`.

## An open page kept rendering captures the server had deleted

The client only mutated its list on fetch, socket append, or explicit delete, never on age. The endpoint page is built to sit open for hours, so a row reading "6 hours ago" ended up on screen directly under the line promising deletion after 4 hours.

The store gains `pruneExpired`, driven from the `TICK_MS` interval the component already runs for relative timestamps, so no second timer. Dropping rows locally is only the immediate half: the list is windowed, so it then calls the existing `fetchRequests()` to resync `total` and promote any older-but-live capture into the window.

The window reaches the page as `data-retention-seconds`, rendered by `renderEndpoint` from the same constant the sweep uses, so there is no fourth hardcoded copy of "4 hours". A page served without the attribute skips pruning rather than expiring against a guess.

## Verification

- `go vet ./src/...`, `go test ./src/...`, `npm run lint`, `prettier --check`, and the `npm run css` staleness check all pass locally.
- New `TestSweepRetention` covers both directions; new `TestPageRoutes` case asserts `data-retention-seconds="14400"`.
- Boot sweep run against a real database: `deleted old requests count=103` logged at startup, before the listener came up.
- Client prune driven in a real browser: deleted captures server-side to simulate a sweep, confirmed the page still rendered 3 phantom rows, aged them past the window, and let the natural 30s tick fire. Rows went 3 to 0, `total` resynced, no console errors. A fresh capture then survived two further ticks.

The e2e suite is not extended here. A Playwright test using `page.clock.fastForward` would guard the client prune, and can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkbFE6pgcxRfsMAvnwyuqS