### PR TITLE
Organise the tests, close the gaps they left, and tidy the prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ them so they still make sense in a year.
   fixes the flicker when..."). Once fixed, that history is noise.
 - No hyper-specific framing: don't tie comments to one-time scenarios; describe
   the generic, reusable purpose instead.
-- Explain intent and non-obvious behavior: why this branch exists, what
+- Explain intent and non-obvious behaviour: why this branch exists, what
   invariant it protects.
 - Flag regression risks the next dev must respect (e.g. "excluded by default so
   new surfaces are safe").
@@ -43,8 +43,8 @@ them so they still make sense in a year.
 ## Client IP is a trust decision
 
 `PLATFORM` selects which header the real client IP is read from, and setting it
-trusts that header unconditionally — httphq cannot tell a platform's header
-from one a client forged. Inbound traffic must not be able to reach the process
+trusts that header unconditionally: httphq cannot tell a platform's header from
+one a client forged. Inbound traffic must not be able to reach the process
 bypassing that platform, or a client can spoof its IP and evade rate limiting.
 Leaving it unset behind a proxy is the opposite failure: every request looks
 like it came from the proxy and rate limiting becomes global.
@@ -52,7 +52,7 @@ like it came from the proxy and rate limiting becomes global.
 ## Captured data is ephemeral
 
 SQLite writes to the container's writable layer. Capture history is lost on
-restart, by design — nothing here is a durable store, and no migration path
+restart, by design. Nothing here is a durable store, and no migration path
 exists for it.
 
 ## Logging

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@
 
 httphq is configured entirely through environment variables.
 
-| Variable          | Default       | Description                                                                                                 |
-| ----------------- | ------------- | ----------------------------------------------------------------------------------------------------------- |
-| `APPLICATION_ENV` | `development` | Set to `production` to bind all interfaces, raise the rate limit, and default logging to `info`.            |
-| `LOG_LEVEL`       | env-dependent | Overrides the log level: `debug`, `info`, `warn`, or `error`.                                               |
-| `PLATFORM`        | `direct`      | The hosting platform in front of httphq — selects which header the real client IP is read from (see below). |
+| Variable          | Default       | Description                                                                                                |
+| ----------------- | ------------- | ---------------------------------------------------------------------------------------------------------- |
+| `APPLICATION_ENV` | `development` | Set to `production` to bind all interfaces, raise the rate limit, and default logging to `info`.           |
+| `LOG_LEVEL`       | env-dependent | Overrides the log level: `debug`, `info`, `warn`, or `error`.                                              |
+| `PLATFORM`        | `direct`      | The hosting platform in front of httphq. Selects which header the real client IP is read from (see below). |
 
 ### `PLATFORM`
 
@@ -40,14 +40,14 @@ httphq derives the client IP (used for rate limiting and shown on captured
 requests) from the header your hosting platform sets. Declare your platform
 and httphq picks the right strategy:
 
-| `PLATFORM`       | Client IP source                                                        |
-| ---------------- | ----------------------------------------------------------------------- |
-| unset / `direct` | The TCP connection peer (no proxy).                                     |
-| `cloudflare`     | `CF-Connecting-IP` header.                                              |
-| `fly`            | `Fly-Client-IP` header.                                                 |
-| `heroku`         | `X-Forwarded-For` (leftmost).                                           |
-| `render`         | `X-Forwarded-For` (leftmost).                                           |
-| `proxy`          | `X-Forwarded-For` (leftmost) — generic nginx / Traefik / load balancer. |
+| `PLATFORM`       | Client IP source                                                             |
+| ---------------- | ---------------------------------------------------------------------------- |
+| unset / `direct` | The TCP connection peer (no proxy).                                          |
+| `cloudflare`     | `CF-Connecting-IP` header.                                                   |
+| `fly`            | `Fly-Client-IP` header.                                                      |
+| `heroku`         | `X-Forwarded-For` (leftmost).                                                |
+| `render`         | `X-Forwarded-For` (leftmost).                                                |
+| `proxy`          | `X-Forwarded-For` (leftmost), for a generic nginx / Traefik / load balancer. |
 
 An unrecognised value falls back to `direct`.
 
@@ -56,7 +56,7 @@ Cloudflare's `Cf-*`) from captured requests, so users inspect their own traffic
 without the noise of whatever provider sits in front of httphq.
 
 > **Security note.** Setting `PLATFORM` trusts that platform's client-IP
-> header unconditionally — httphq cannot tell a real platform header from one
+> header unconditionally: httphq cannot tell a real platform header from one
 > a client forged. You must ensure inbound traffic cannot reach httphq
 > bypassing the platform (e.g. lock your origin to the platform's IP ranges),
 > or a client can spoof its IP and evade rate limiting. Conversely, if you run

--- a/docs/api.md
+++ b/docs/api.md
@@ -86,7 +86,8 @@ before the first request has something to advance from.
 ## Limits
 
 - **128 captures** per listing response.
-- **1 MiB** request body. Larger captures are rejected.
+- **1 MiB** request body. Anything larger is answered `413` and stored
+  nowhere, so an oversized payload leaves no capture behind.
 - **150 requests per minute per client IP** in production, across everything:
   page loads, captures and API calls share one budget. The recommended
   2 second poll is 30 a minute, which leaves room for the traffic under test.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -59,6 +59,14 @@ CGO_ENABLED=0 go build -o ./bin/httphq ./src
 cd e2e && npx playwright test
 ```
 
+The suite drives a real browser against a real binary, so it needs the port that
+binary listens on. `port` in `src/application.go` is a constant; to run beside
+something already holding 8080, change it and point the suite at the same place:
+
+```bash
+HTTPHQ_BASE_URL=http://localhost:8099 npx playwright test
+```
+
 View test coverage:
 
 ```bash

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,14 +1,19 @@
 import { defineConfig, devices } from "@playwright/test";
+import { BASE_URL } from "./tests/support/harness";
 
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // Bounded rather than left to the core count. Every page load pulls Alpine
+  // and the syntax highlighter from public CDNs, with no cache shared between
+  // contexts, so the ceiling that matters is how many simultaneous third-party
+  // fetches stay reliable rather than how many browsers the machine can run.
+  workers: process.env.CI ? 1 : 4,
   reporter: process.env.CI ? "github" : "list",
   use: {
-    baseURL: "http://localhost:8080",
+    baseURL: BASE_URL,
     trace: "on-first-retry",
     permissions: ["clipboard-read", "clipboard-write"],
   },
@@ -21,7 +26,7 @@ export default defineConfig({
   webServer: {
     command: "./bin/httphq",
     cwd: "..",
-    url: "http://localhost:8080/api/health",
+    url: `${BASE_URL}/api/health`,
     reuseExistingServer: !process.env.CI,
     timeout: 30_000,
   },

--- a/e2e/tests/capture-api.spec.ts
+++ b/e2e/tests/capture-api.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { captureUrl, newEndpointId, requestsUrl } from "./support/harness";
+import { captureUrl, listRequests, newEndpointId } from "./support/harness";
 
 /**
  * What only a real socket can show. The Go suite drives the same routes through
@@ -11,15 +11,29 @@ test.describe("Capture API", () => {
   test.describe("Body limit", () => {
     // A shared instance writes to one disk, so an unbounded body is one
     // caller's ability to fill it for everyone.
+    //
+    // The server answers 413 and closes without draining the rest of the body,
+    // so a client still writing sees the connection go instead of the reply.
+    // Both are the same refusal and which one lands depends on how far the
+    // write had got, so the assertion that holds either way is that nothing
+    // was stored.
     test("a body over the limit is rejected", async ({ request }) => {
+      const endpointId = newEndpointId();
       const overOneMebibyte = "a".repeat(1024 * 1024 + 1);
 
-      const response = await request.post(captureUrl(newEndpointId()), {
-        data: overOneMebibyte,
-        headers: { "Content-Type": "text/plain" },
-      });
+      const outcome = await request
+        .post(captureUrl(endpointId), {
+          data: overOneMebibyte,
+          headers: { "Content-Type": "text/plain" },
+        })
+        .then((response): number | string => response.status())
+        .catch(() => "connection closed");
 
-      expect(response.status()).toBe(413);
+      expect([413, "connection closed"]).toContain(outcome);
+
+      expect((await listRequests(request, endpointId)).requests).toHaveLength(
+        0,
+      );
     });
 
     test("a body at the limit is accepted", async ({ request }) => {
@@ -33,11 +47,8 @@ test.describe("Capture API", () => {
 
       expect(response.status()).toBe(200);
 
-      const listing = await request.get(requestsUrl(endpointId));
-      const payload = (await listing.json()) as {
-        requests: { body: string }[];
-      };
-      expect(payload.requests[0].body).toHaveLength(oneMebibyte.length);
+      const listing = await listRequests(request, endpointId);
+      expect(listing.requests[0].body).toHaveLength(oneMebibyte.length);
     });
   });
 });

--- a/e2e/tests/endpoint-screen.spec.ts
+++ b/e2e/tests/endpoint-screen.spec.ts
@@ -10,6 +10,13 @@ import {
   type HarDocument,
 } from "./support/harness";
 
+/**
+ * How long the page is given to hydrate. Alpine is loaded from a CDN, so first
+ * paint of anything interactive waits on a third party rather than on the
+ * server under test.
+ */
+const HYDRATION_TIMEOUT_MS = 15_000;
+
 test.describe("Endpoint screen", () => {
   let endpointId: string;
   let endpointPath: string;
@@ -20,9 +27,18 @@ test.describe("Endpoint screen", () => {
     endpointPath = `/to/${endpointId}`;
     endpointUrl = captureUrl(endpointId);
     await page.goto(`/${endpointId}`);
-    // Wait for Alpine to mount and the empty state to render so subsequent
-    // assertions don't race with initialization.
-    await expect(page.locator('[data-test="endpoint-url"]')).toBeVisible();
+    // Gate on something only Alpine can have rendered. The endpoint URL and
+    // every other server-rendered element is on screen before the page has
+    // hydrated, so waiting on one lets each test start racing a boot that has
+    // a third-party script in front of it. The waiting panel is the first
+    // thing the mounted component draws on an endpoint with no traffic.
+    //
+    // Given longer than an ordinary assertion because it is waiting on that
+    // script to arrive from a CDN, which is slower and less predictable than
+    // anything the app itself does.
+    await expect(page.locator('[data-test="empty-waiting"]')).toBeVisible({
+      timeout: HYDRATION_TIMEOUT_MS,
+    });
   });
 
   test.describe("Page", () => {
@@ -150,6 +166,18 @@ test.describe("Endpoint screen", () => {
       await expect(headers).toContainText("X-One");
       await expect(headers).toContainText("X-Two");
       await expect(headers).toContainText(/Headers\s*\(\d+\)/);
+    });
+
+    // The size is the reason to open a card before copying it, and it is stated
+    // in units rather than raw bytes so a large payload reads at a glance.
+    test("the body panel states the payload size", async ({
+      page,
+      request,
+    }) => {
+      await send(request, endpointUrl, { data: "a".repeat(2048) });
+      const body = page.locator('[data-test="request-body"]').first();
+
+      await expect(body).toContainText("2.0 KB");
     });
 
     test("delete-request removes a single card", async ({ page, request }) => {
@@ -410,6 +438,23 @@ test.describe("Endpoint screen", () => {
 
       await page.locator('[data-test="search-input"]').fill("charge.succeeded");
       await expect(results).toContainText("1 result");
+    });
+
+    // A counter that says "1 results" reads as a defect in the thing being
+    // counted rather than in the sentence.
+    test("the result count agrees in number with what is on screen", async ({
+      page,
+      request,
+    }) => {
+      await send(request, endpointUrl, { data: "only" });
+      await expect(page.locator('[data-test="search-results"]')).toHaveText(
+        "1 result",
+      );
+
+      await send(request, endpointUrl, { data: "second" });
+      await expect(page.locator('[data-test="search-results"]')).toHaveText(
+        "2 results",
+      );
     });
 
     test("the method filter narrows the list to matching methods", async ({

--- a/e2e/tests/support/harness.ts
+++ b/e2e/tests/support/harness.ts
@@ -1,12 +1,20 @@
 import type { APIRequestContext, Page } from "@playwright/test";
 
-/** Where the server under test is reachable, matching the Playwright baseURL. */
-export const BASE_URL = "http://localhost:8080";
+/**
+ * Where the server under test is reachable. Spelled once: the Playwright config
+ * reads it as both its baseURL and its readiness probe, so the suite and the
+ * server it starts cannot disagree about where to look.
+ *
+ * `port` in src/application.go is a constant, so the override is for the one
+ * case that constant anticipates: running beside something that already holds
+ * 8080, with the constant changed to match.
+ */
+export const BASE_URL = process.env.HTTPHQ_BASE_URL ?? "http://localhost:8080";
 
 /**
- * A fresh endpoint ID for one test. Endpoints are implicit — a page exists for
- * any well-formed ID — so a unique ID per test is all the isolation needed to
- * keep one test's captures out of another's stream.
+ * A fresh endpoint ID for one test. Endpoints are implicit, in that a page
+ * exists for any well-formed ID, so a unique ID per test is all the isolation
+ * needed to keep one test's captures out of another's stream.
  */
 export const newEndpointId = () =>
   `e2e-${Math.random().toString(36).slice(2, 8)}`;
@@ -53,13 +61,50 @@ export const send = (
   { method = "POST", ...init }: SendOptions = {},
 ) => request.fetch(url, { method, ...init });
 
+/**
+ * One capture, as the JSON API hands it over. Headers are scalar-or-array
+ * because a header may repeat; see flattenHeaders in src/capture.go.
+ */
+export type CapturedRequest = {
+  uuid: string;
+  endpointId: string;
+  ip: string;
+  method: string;
+  path: string;
+  queryString: string;
+  body: string;
+  createdAt: string;
+  headers: Record<string, string | string[]>;
+};
+
+/** The listing response, as the page and any poller read it. */
+export type RequestListing = {
+  requests: CapturedRequest[];
+  total: number;
+  cursor: string;
+  hasMore: boolean;
+};
+
+/**
+ * Reads back what an endpoint has captured. `APIResponse.json` cannot know the
+ * shape it returns, so this is the one place the listing's is declared rather
+ * than proven, confined here so no test has to declare its own.
+ */
+export const listRequests = async (
+  request: APIRequestContext,
+  endpointId: string,
+): Promise<RequestListing> => {
+  const response = await request.get(requestsUrl(endpointId));
+  return (await response.json()) as RequestListing;
+};
+
 export const readClipboard = (page: Page) =>
   page.evaluate(() => navigator.clipboard.readText());
 
 /**
- * Reads the clipboard as JSON of an expected shape. The assertion is the one
- * place a shape is declared rather than proven — `JSON.parse` cannot know it —
- * and it is deliberately confined here so no test has to make its own.
+ * Reads the clipboard as JSON of an expected shape. Confined here for the same
+ * reason as listRequests: `JSON.parse` cannot know the shape it returns, so the
+ * one declaration of it lives in the harness rather than in each test.
  */
 export const readClipboardJson = async <T>(page: Page): Promise<T> =>
   JSON.parse(await readClipboard(page)) as T;

--- a/public/endpoint.js
+++ b/public/endpoint.js
@@ -36,7 +36,9 @@
   }
 
   document.addEventListener("alpine:init", () => {
-    // Only initialise when the endpoint page is rendered.
+    // The page scripts are loaded as a set, and only the endpoint page asks
+    // for them. Registering the store and the component regardless would put
+    // both on any page that later loads the set for one of the other helpers.
     const isEndpointPage = !!document.querySelector(
       'main[x-data^="endpointPage"]',
     );
@@ -169,6 +171,12 @@
       _socket: null,
       _closed: false,
 
+      // The page has exactly one store, and every reader below reaches for it.
+      // Naming it once keeps the lookup out of the expressions that use it.
+      get store() {
+        return Alpine.store("main");
+      },
+
       // Alpine calls this once when the component mounts. Endpoint id and
       // WebSocket URL come from data-* attributes on the root element so the
       // method can match Alpine's expected `init()` signature.
@@ -184,11 +192,11 @@
           Number.isFinite(retentionSeconds) && retentionSeconds > 0
             ? retentionSeconds * 1000
             : 0;
-        Alpine.store("main").setEndpoint(endpointId);
+        this.store.setEndpoint(endpointId);
         this._connectWebSocket();
         setInterval(() => {
           this.tick++;
-          Alpine.store("main").pruneExpired(this._retentionMs);
+          this.store.pruneExpired(this._retentionMs);
         }, TICK_MS);
         document.addEventListener("visibilitychange", () => {
           if (!document.hidden) this._clearUnread();
@@ -204,19 +212,19 @@
       // panel that asserts the first while the second is true tells the user
       // their traffic never landed.
       get streamState() {
-        if (Alpine.store("main").visibleRequests.length > 0) return "list";
-        if (Alpine.store("main").filtered) return "filtered";
+        if (this.store.visibleRequests.length > 0) return "list";
+        if (this.store.filtered) return "filtered";
         return "waiting";
       },
 
       get renderedRequests() {
-        return Alpine.store("main").visibleRequests.slice(0, this.renderLimit);
+        return this.store.visibleRequests.slice(0, this.renderLimit);
       },
 
       get hiddenCount() {
         return Math.max(
           0,
-          Alpine.store("main").visibleRequests.length - this.renderLimit,
+          this.store.visibleRequests.length - this.renderLimit,
         );
       },
 
@@ -236,7 +244,7 @@
           this._reconnectDelay = RECONNECT_MIN_MS;
           // Traffic that landed while the socket was down is not replayed, so
           // refetch to close the gap rather than silently missing it.
-          Alpine.store("main").fetchRequests();
+          this.store.fetchRequests();
         });
 
         socket.addEventListener("message", (payload) => {
@@ -246,7 +254,7 @@
           } catch {
             return;
           }
-          Alpine.store("main").addRequest(request);
+          this.store.addRequest(request);
           this.announce(`${request.method} request received`);
           if (document.hidden) {
             this._unread += 1;
@@ -330,7 +338,6 @@
         return this._copyAndFlash(text, key, "Copied to clipboard");
       },
 
-      // Copies requests as a HAR-shaped document.
       copyHar(requests, key) {
         return this._copyAndFlash(
           window.buildHarExport(requests),
@@ -344,15 +351,14 @@
       },
 
       async deleteAllConfirmed() {
-        const count = Alpine.store("main").requests.length;
+        const count = this.store.requests.length;
         this.pendingDeleteAll = false;
-        await Alpine.store("main").deleteRequests();
+        await this.store.deleteRequests();
         this.announce(`Deleted ${window.pluralize(count, "request")}`);
       },
 
       async sendCustom() {
-        const store = Alpine.store("main");
-        if (!store.endpointId) return;
+        if (!this.store.endpointId) return;
         const parsed = window.parseHeaderLines(this.sendForm.headers);
         if (parsed.invalid.length) {
           this.sendFailed = true;
@@ -361,7 +367,7 @@
           return;
         }
         const path = this.sendForm.path.replace(/^\/+/, "");
-        const target = `/to/${store.endpointId}${path ? "/" + path : ""}`;
+        const target = `/to/${this.store.endpointId}${path ? "/" + path : ""}`;
         try {
           this.sendFailed = false;
           this.sendStatus = "Sending…";

--- a/public/har.js
+++ b/public/har.js
@@ -72,7 +72,7 @@
         queryString: entryQueryString(request.queryString),
         ...(postData ? { postData } : {}),
         // Byte length of the captured body, which httphq stores as a Go
-        // string — encoding/json replaces invalid UTF-8 with U+FFFD on
+        // string, and encoding/json replaces invalid UTF-8 with U+FFFD on
         // marshal, so for genuinely binary uploads this can differ from the
         // true original size. See database.Request.Body.
         bodySize: new TextEncoder().encode(body).length,

--- a/public/index.js
+++ b/public/index.js
@@ -25,13 +25,15 @@ window.formatTimeAgo = function (date) {
   return "";
 };
 
-/* Clipboard helper */
+/* Copying to the clipboard. The async API is unavailable outside a secure
+   context, which a self-hosted deployment reached over plain HTTP is, so the
+   older selection-based path stays as the fallback rather than leaving those
+   deployments with dead copy buttons. */
 
 window.copyToClipboard = async function (text) {
   if (navigator.clipboard && window.isSecureContext) {
     return navigator.clipboard.writeText(text);
   }
-  // Fallback: temporary textarea
   const ta = document.createElement("textarea");
   ta.value = text;
   ta.setAttribute("readonly", "");

--- a/public/render-body.js
+++ b/public/render-body.js
@@ -119,7 +119,7 @@ function parseMultipart(body, boundary) {
       filename: filenameMatch[1],
       contentType,
       // Byte length of the captured body, which httphq stores as a Go
-      // string — encoding/json replaces invalid UTF-8 with U+FFFD on
+      // string, and encoding/json replaces invalid UTF-8 with U+FFFD on
       // marshal, so for genuinely binary uploads this can differ from the
       // true original file size. See database.Request.Body.
       size: new TextEncoder().encode(content).length,
@@ -135,16 +135,17 @@ window.renderBody = function (body, headers) {
   if (boundary) {
     const parts = parseMultipart(body, boundary);
     if (parts !== null) return highlightPrettyJSON(parts);
-    // Malformed multipart body — fall through to the generic paths below.
+    // Malformed multipart body: fall through to the generic paths below.
   }
 
-  // Best-effort JSON pretty + highlight.
+  // Each strategy claims less about the payload than the one before it, and
+  // falls through rather than reporting a failure: a body that answers to none
+  // of them is still a body the reader needs in front of them.
   try {
     return highlightPrettyJSON(JSON.parse(body));
   } catch {
     // not JSON
   }
-  // Heuristic: looks like XML/HTML if it starts with '<'
   if (body.trimStart().startsWith("<")) {
     return highlight(body, "xml");
   }

--- a/scripts/social-card.mjs
+++ b/scripts/social-card.mjs
@@ -45,7 +45,9 @@ try {
 
   const unset = await page.evaluate((tokens) => {
     const styles = getComputedStyle(document.documentElement);
-    return tokens.filter((token) => styles.getPropertyValue(token).trim() === "");
+    return tokens.filter(
+      (token) => styles.getPropertyValue(token).trim() === "",
+    );
   }, REQUIRED_TOKENS);
   if (unset.length > 0) {
     throw new Error(

--- a/src/api_test.go
+++ b/src/api_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"net/http"
-	"net/url"
 	"strconv"
 	"testing"
 	"time"
@@ -13,37 +12,6 @@ import (
 
 	"httphq/src/database"
 )
-
-type requestListing struct {
-	Requests []database.Request `json:"requests"`
-	Total    int64              `json:"total"`
-	Cursor   string             `json:"cursor"`
-	HasMore  bool               `json:"hasMore"`
-}
-
-// listRequests reads back what an endpoint has captured, through the same API
-// the page uses. An empty `since` is the browser's call, with no cursor.
-func listRequests(t *testing.T, id, search, since string) requestListing {
-	t.Helper()
-
-	response := get(t, "/api/endpoints/"+id+"/requests?search="+search+
-		"&since="+url.QueryEscape(since))
-	require.Equal(t, http.StatusOK, response.StatusCode)
-
-	var payload requestListing
-	require.NoError(t, json.Unmarshal([]byte(bodyOf(t, response)), &payload))
-	return payload
-}
-
-func capturedRequests(t *testing.T, id, search string) []database.Request {
-	t.Helper()
-	return listRequests(t, id, search, "").Requests
-}
-
-func listedTotal(t *testing.T, id, search string) int64 {
-	t.Helper()
-	return listRequests(t, id, search, "").Total
-}
 
 func TestHandleHealth(t *testing.T) {
 	t.Run("answers 200 so a platform probe can reach it", func(t *testing.T) {
@@ -248,6 +216,23 @@ func TestHandleListRequestsCursor(t *testing.T) {
 	})
 }
 
+func TestHandleDeleteRequests(t *testing.T) {
+	t.Run("deleting an endpoint's captures clears only that endpoint", func(t *testing.T) {
+		id, other := endpointID(t), endpointID(t)+"-other"
+		post(t, "/to/"+id, "x")
+		post(t, "/to/"+other, "y")
+
+		response := do(t, testRequest{
+			method: http.MethodDelete,
+			path:   "/api/endpoints/" + id + "/requests",
+		})
+
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		assert.Empty(t, capturedRequests(t, id, ""))
+		assert.Len(t, capturedRequests(t, other, ""), 1)
+	})
+}
+
 func TestHandleDeleteRequest(t *testing.T) {
 	t.Run("deleting one capture leaves the rest", func(t *testing.T) {
 		id := endpointID(t)
@@ -264,22 +249,5 @@ func TestHandleDeleteRequest(t *testing.T) {
 		captured := capturedRequests(t, id, "")
 		require.Len(t, captured, 1)
 		assert.Equal(t, "keep", captured[0].Body)
-	})
-}
-
-func TestHandleDeleteRequests(t *testing.T) {
-	t.Run("deleting an endpoint's captures clears only that endpoint", func(t *testing.T) {
-		id, other := endpointID(t), endpointID(t)+"-other"
-		post(t, "/to/"+id, "x")
-		post(t, "/to/"+other, "y")
-
-		response := do(t, testRequest{
-			method: http.MethodDelete,
-			path:   "/api/endpoints/" + id + "/requests",
-		})
-
-		assert.Equal(t, http.StatusOK, response.StatusCode)
-		assert.Empty(t, capturedRequests(t, id, ""))
-		assert.Len(t, capturedRequests(t, other, ""), 1)
 	})
 }

--- a/src/application.go
+++ b/src/application.go
@@ -82,7 +82,7 @@ func newApplication(config applicationConfig) *fiber.App {
 		ProxyHeader:      fiber.HeaderXForwardedFor,
 	})
 
-	// Runs first so every request — including rate-limited ones — gets a
+	// Runs first so every request, including the rate-limited ones, gets a
 	// correlation ID and a structured access-log line.
 	application.Use(requestLogger)
 
@@ -114,7 +114,7 @@ func newApplication(config applicationConfig) *fiber.App {
 
 	application.Get("/", renderIndex(assets))
 	application.Get("/contact", renderContact(assets))
-	application.Get("/:endpoint", requireValidEndpoint, renderEndpoint)
+	application.Get("/:endpoint", requireValidEndpoint, renderEndpoint(assets))
 	application.Post("/endpoint", createEndpoint(haikunator.New()))
 
 	// Prefix-matched so everything after the endpoint ID is captured as the

--- a/src/application_test.go
+++ b/src/application_test.go
@@ -24,7 +24,10 @@ func storeCapture(t *testing.T, endpointID, uuid string, createdAt time.Time) {
 	})
 }
 
-func uuidsFor(ctx context.Context, endpointID string) []string {
+// storedUUIDs is what the database still holds for an endpoint. Named for the
+// store rather than the endpoint so it does not read as the socket registry's
+// uuidsFor, which answers a different question about the same ID.
+func storedUUIDs(ctx context.Context, endpointID string) []string {
 	var uuids []string
 	for _, request := range database.GetRequestsForEndpointID(ctx, endpointID, "", time.Time{}, 10) {
 		uuids = append(uuids, request.UUID)
@@ -57,7 +60,7 @@ func TestSweepRetention(t *testing.T) {
 
 		sweepRetention()
 
-		assert.Empty(t, uuidsFor(t.Context(), endpointID))
+		assert.Empty(t, storedUUIDs(t.Context(), endpointID))
 	})
 
 	t.Run("keeps captures inside the retention window", func(t *testing.T) {
@@ -67,7 +70,7 @@ func TestSweepRetention(t *testing.T) {
 
 		sweepRetention()
 
-		assert.Equal(t, []string{"sweep-recent-live"}, uuidsFor(t.Context(), endpointID))
+		assert.Equal(t, []string{"sweep-recent-live"}, storedUUIDs(t.Context(), endpointID))
 	})
 }
 
@@ -83,6 +86,6 @@ func TestStartRetentionSweep(t *testing.T) {
 		scheduler := startRetentionSweep()
 		t.Cleanup(func() { scheduler.Stop() })
 
-		assert.Empty(t, uuidsFor(t.Context(), endpointID))
+		assert.Empty(t, storedUUIDs(t.Context(), endpointID))
 	})
 }

--- a/src/assets_test.go
+++ b/src/assets_test.go
@@ -23,7 +23,7 @@ var assetHelperCall = regexp.MustCompile("\\{\\{asset `(/[a-zA-Z0-9._-]+\\.(?:cs
 
 // versionedURL matches the shape the helper emits: the path, then the short
 // content hash it appends.
-var versionedURL = regexp.MustCompile(`^(/[a-zA-Z0-9._-]+)\?v=[0-9a-f]{10}$`)
+var versionedURL = regexp.MustCompile(`^/[a-zA-Z0-9._-]+\?v=[0-9a-f]{10}$`)
 
 func templateFiles(t *testing.T) []string {
 	t.Helper()
@@ -52,6 +52,17 @@ func assetDir(t *testing.T) string {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, path), []byte("/* "+path+" */"), 0o600))
 	}
 	return dir
+}
+
+// rewriteAsset replaces an asset's contents and moves its modification time,
+// which is what the reload check keys on. Filesystem timestamp resolution is
+// coarse enough that a same-instant rewrite would otherwise look unchanged.
+func rewriteAsset(t *testing.T, dir, path, contents string) {
+	t.Helper()
+	full := filepath.Join(dir, path)
+	require.NoError(t, os.WriteFile(full, []byte(contents), 0o600))
+	later := time.Now().Add(time.Second)
+	require.NoError(t, os.Chtimes(full, later, later))
 }
 
 // A stylesheet or script served from a fixed path lets a cache pair one deploy's
@@ -149,6 +160,19 @@ func TestAssetIndex(t *testing.T) {
 		assert.Equal(t, "/logo.png", index.url("/logo.png"))
 	})
 
+	// Reload hashes whatever it is asked for, so a path missing from
+	// versionedAssets is versioned in development and unversioned in
+	// production. That divergence is why the template check above exists: a new
+	// script referenced through the helper looks correct locally right up until
+	// it ships.
+	t.Run("reload versions a path the startup pass never hashed", func(t *testing.T) {
+		dir := assetDir(t)
+		rewriteAsset(t, dir, "/unlisted.js", "/* unlisted */")
+
+		assert.Equal(t, "/unlisted.js", newAssetIndex(dir, false).url("/unlisted.js"))
+		assert.Regexp(t, versionedURL, newAssetIndex(dir, true).url("/unlisted.js"))
+	})
+
 	t.Run("reload picks up an edited asset without a restart", func(t *testing.T) {
 		dir := assetDir(t)
 		index := newAssetIndex(dir, true)
@@ -176,15 +200,4 @@ func TestAssetIndex(t *testing.T) {
 
 		assert.Equal(t, index.url("/app.css"), index.url("/app.css"))
 	})
-}
-
-// rewriteAsset replaces an asset's contents and moves its modification time,
-// which is what the reload check keys on. Filesystem timestamp resolution is
-// coarse enough that a same-instant rewrite would otherwise look unchanged.
-func rewriteAsset(t *testing.T, dir, path, contents string) {
-	t.Helper()
-	full := filepath.Join(dir, path)
-	require.NoError(t, os.WriteFile(full, []byte(contents), 0o600))
-	later := time.Now().Add(time.Second)
-	require.NoError(t, os.Chtimes(full, later, later))
 }

--- a/src/capture.go
+++ b/src/capture.go
@@ -84,10 +84,20 @@ func flattenHeaders(headers map[string][]string) map[string]any {
 }
 
 // captureRequest stores an inbound request against its endpoint and pushes it to
-// every socket watching that endpoint. It answers 200 whatever the payload:
-// there is nothing a caller can send that httphq will not record.
+// every socket watching that endpoint. It answers 200 for anything within the
+// body limit: there is nothing else a caller can send that httphq will not
+// record.
 func captureRequest(registry *socketRegistry) fiber.Handler {
 	return func(c fiber.Ctx) error {
+		// The body limit is enforced around the handler rather than in front of
+		// it. A request declaring more than the limit still arrives here, with
+		// its body dropped, and is answered 413 on the way out. Storing it
+		// would leave a bodyless capture in the stream, which reads as a sender
+		// that sent nothing rather than as a payload that was refused.
+		if c.Request().Header.ContentLength() > bodyLimit {
+			return c.SendStatus(http.StatusRequestEntityTooLarge)
+		}
+
 		endpointID := c.Params("endpoint")
 
 		headers := captureHeaders(c.GetReqHeaders())

--- a/src/capture_test.go
+++ b/src/capture_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -75,6 +76,54 @@ func TestCaptureRequest(t *testing.T) {
 		assert.NotContains(t, headers, "Via")
 	})
 
+	// flattenHeaders decides the stored shape, and every consumer downstream
+	// reads it: the request panel, the search index and the HAR export all
+	// expect a scalar or a list. This drives a real request through the wire so
+	// the shape is proven where it is actually produced.
+	t.Run("a repeated header is stored as a list, a single one as a scalar", func(t *testing.T) {
+		id := endpointID(t)
+
+		do(t, testRequest{
+			method:   http.MethodPost,
+			path:     "/to/" + id,
+			body:     "x",
+			headers:  map[string]string{"X-Single": "one"},
+			repeated: map[string][]string{"X-Multi": {"first", "second"}},
+		})
+
+		captured := capturedRequests(t, id, "")
+		require.Len(t, captured, 1)
+		var headers map[string]any
+		require.NoError(t, json.Unmarshal(captured[0].Headers, &headers))
+		assert.Equal(t, "one", headers["X-Single"])
+		assert.Equal(t, []any{"first", "second"}, headers["X-Multi"])
+	})
+
+	// The opt-in is read off the wire rather than from a map a test built, so
+	// this covers the header name and value the browser actually sends.
+	t.Run("spoofing curl is honoured on a request off the wire", func(t *testing.T) {
+		id := endpointID(t)
+
+		do(t, testRequest{
+			method: http.MethodPost,
+			path:   "/to/" + id,
+			body:   "hello=world",
+			headers: map[string]string{
+				spoofCurlHeader: "true",
+				"User-Agent":    "Mozilla/5.0",
+				"Origin":        "https://example.com",
+			},
+		})
+
+		captured := capturedRequests(t, id, "")
+		require.Len(t, captured, 1)
+		headers := string(captured[0].Headers)
+		assert.Contains(t, headers, "curl/7.79.1")
+		assert.NotContains(t, headers, "Mozilla")
+		assert.NotContains(t, headers, "Origin")
+		assert.NotContains(t, headers, spoofCurlHeader)
+	})
+
 	t.Run("an empty body is captured as an empty body", func(t *testing.T) {
 		id := endpointID(t)
 
@@ -97,18 +146,24 @@ func TestCaptureRequest(t *testing.T) {
 	})
 
 	// The limit is what keeps one caller from filling the disk a whole shared
-	// instance writes to. It is enforced by the server rather than the handler,
-	// so the transport refuses the payload and the caller never gets an answer
-	// that would read as a successful capture. The status a real client sees is
-	// covered end to end, where there is a socket to see it on.
+	// instance writes to. The transport refuses the payload, so the caller never
+	// gets an answer that would read as a successful capture.
+	//
+	// The in-memory transport will not send a body shorter than the length it
+	// declares, so the handler's own guard against an oversized declaration
+	// cannot be reached from here. It is covered end to end, where there is a
+	// socket to see both the status and what the endpoint was left holding.
 	t.Run("a body over the limit is refused by the transport", func(t *testing.T) {
-		request := httptest.NewRequest(http.MethodPost, "/to/"+endpointID(t),
+		id := endpointID(t)
+		request := httptest.NewRequest(http.MethodPost, "/to/"+id,
 			strings.NewReader(strings.Repeat("a", bodyLimit+1)))
 
 		_, err := application(t).Test(request)
 
 		require.Error(t, err)
+		assert.Empty(t, capturedRequests(t, id, ""))
 	})
+
 }
 
 func TestCaptureHeaders(t *testing.T) {

--- a/src/database/database.go
+++ b/src/database/database.go
@@ -25,37 +25,41 @@ type Request struct {
 
 var DB *gorm.DB
 
+// logQueryError records a failed query and nothing else. Every operation in
+// this package answers with a zero value rather than an error: the caller is a
+// request handler that still has to respond, and a capture surface that comes
+// back empty is more use than one that refuses to render. The failure has to
+// reach the logs, because nothing above here will report it.
+func logQueryError(ctx context.Context, result *gorm.DB, message string, attrs ...any) {
+	if result.Error == nil {
+		return
+	}
+	slog.ErrorContext(ctx, message, append([]any{"err", result.Error}, attrs...)...)
+}
+
+// Connect opens the store and brings the schema up to date, publishing it as DB
+// only once both have succeeded. Either failure ends the process: there is
+// nothing to serve without somewhere to write captures.
 func Connect(dsn string) *gorm.DB {
-	slog.Info("connecting to database")
-
-	var err error
-
-	DB, err = gorm.Open(sqlite.Open(dsn), &gorm.Config{})
-
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	if err != nil {
 		slog.Error("database connection failed", "err", err)
 		os.Exit(1)
 	}
-
-	slog.Info("database connected")
-
-	slog.Info("migrating database")
-
-	if err := DB.AutoMigrate(&Request{}); err != nil {
+	if err := db.AutoMigrate(&Request{}); err != nil {
 		slog.Error("database migration failed", "err", err)
 		os.Exit(1)
 	}
 
-	slog.Info("database migrated")
+	DB = db
+	slog.Info("database connected and migrated")
 	return DB
 }
 
 func CountRequests(ctx context.Context) int64 {
 	var count int64
 	result := DB.Model(&Request{}).Count(&count)
-	if result.Error != nil {
-		slog.ErrorContext(ctx, "count requests failed", "err", result.Error)
-	}
+	logQueryError(ctx, result, "count requests failed")
 	return count
 }
 
@@ -66,9 +70,7 @@ func CountRequests(ctx context.Context) int64 {
 func CountRequestsForEndpointID(ctx context.Context, endpointID string) int64 {
 	var count int64
 	result := DB.Model(&Request{}).Where(&Request{EndpointID: endpointID}).Count(&count)
-	if result.Error != nil {
-		slog.ErrorContext(ctx, "count requests for endpoint failed", "err", result.Error, "endpoint_id", endpointID)
-	}
+	logQueryError(ctx, result, "count requests for endpoint failed", "endpoint_id", endpointID)
 	return count
 }
 
@@ -100,9 +102,7 @@ func GetRequestsForEndpointID(
 	}
 
 	result := query.Find(&items)
-	if result.Error != nil {
-		slog.ErrorContext(ctx, "get requests failed", "err", result.Error, "endpoint_id", endpointID)
-	}
+	logQueryError(ctx, result, "get requests failed", "endpoint_id", endpointID)
 	return items
 }
 
@@ -120,32 +120,22 @@ func CreateRequest(ctx context.Context, request *Request) {
 	}
 	request.CreatedAt = request.CreatedAt.UTC()
 
-	result := DB.Create(&request)
-	if result.Error != nil {
-		slog.ErrorContext(ctx, "create request failed", "err", result.Error)
-	}
+	logQueryError(ctx, DB.Create(&request), "create request failed")
 }
 
 func DeleteRequestsForEndpointID(ctx context.Context, endpointID string) {
-	result := DB.Where(&Request{EndpointID: endpointID}).Delete(&Request{})
-	if result.Error != nil {
-		slog.ErrorContext(ctx, "delete requests failed", "err", result.Error, "endpoint_id", endpointID)
-	}
+	logQueryError(ctx, DB.Where(&Request{EndpointID: endpointID}).Delete(&Request{}),
+		"delete requests failed", "endpoint_id", endpointID)
 }
 
 func DeleteRequestForUUID(ctx context.Context, UUID string) {
-	result := DB.Where(&Request{UUID: UUID}).Delete(&Request{})
-	if result.Error != nil {
-		slog.ErrorContext(ctx, "delete request failed", "err", result.Error)
-	}
+	logQueryError(ctx, DB.Where(&Request{UUID: UUID}).Delete(&Request{}), "delete request failed")
 }
 
 func DeleteOldRequests(ctx context.Context, threshold time.Time) {
 	// UTC for the same reason as the cursor in GetRequestsForEndpointID: the
 	// comparison is textual, so both sides have to agree on a zone.
 	result := DB.Where("created_at < ?", threshold.UTC()).Delete(&Request{})
-	if result.Error != nil {
-		slog.ErrorContext(ctx, "delete old requests failed", "err", result.Error)
-	}
+	logQueryError(ctx, result, "delete old requests failed")
 	slog.InfoContext(ctx, "deleted old requests", "count", result.RowsAffected)
 }

--- a/src/endpoint.go
+++ b/src/endpoint.go
@@ -9,8 +9,8 @@ import (
 
 // endpointIDPattern bounds an endpoint ID to the shape haikunator emits
 // (lowercase words and digits joined by hyphens). Rejecting anything else
-// keeps attacker-controlled characters — quotes, angle brackets, parens —
-// out of the rendered pages, the database, and the logs.
+// keeps attacker-controlled characters (quotes, angle brackets, parens) out of
+// the rendered pages, the database, and the logs.
 var endpointIDPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
 func validEndpointID(id string) bool {

--- a/src/harness_test.go
+++ b/src/harness_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -65,11 +67,26 @@ func endpointID(t *testing.T) string {
 	return "test-" + strconv.FormatUint(endpointCounter.Add(1), 10)
 }
 
+// withPlatform points the process-wide platform config at name for the duration
+// of one test. Client-IP resolution and header stripping both read that global,
+// so a test that changes it has to put it back.
+func withPlatform(t *testing.T, name string) {
+	t.Helper()
+	previous := currentPlatform
+	currentPlatform = resolvePlatform(name)
+	t.Cleanup(func() { currentPlatform = previous })
+}
+
 type testRequest struct {
 	method  string
 	path    string
 	body    string
 	headers map[string]string
+	// repeated carries headers sent more than once, which the single-valued
+	// map above cannot express. RFC 7230 allows a header to repeat and the
+	// capture handler stores those values as a list, so the two shapes are
+	// spelled apart rather than collapsed.
+	repeated map[string][]string
 }
 
 func do(t *testing.T, spec testRequest) *http.Response {
@@ -82,6 +99,11 @@ func do(t *testing.T, spec testRequest) *http.Response {
 	req := httptest.NewRequest(spec.method, spec.path, body)
 	for name, value := range spec.headers {
 		req.Header.Set(name, value)
+	}
+	for name, values := range spec.repeated {
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
 	}
 
 	response, err := application(t).Test(req)
@@ -113,4 +135,38 @@ func bodyOf(t *testing.T, response *http.Response) string {
 func prose(t *testing.T, response *http.Response) string {
 	t.Helper()
 	return strings.Join(strings.Fields(bodyOf(t, response)), " ")
+}
+
+// requestListing is the listing response, decoded. Tests read what an endpoint
+// captured back through the same API the page polls, so a capture is only
+// proven stored once it is also readable.
+type requestListing struct {
+	Requests []database.Request `json:"requests"`
+	Total    int64              `json:"total"`
+	Cursor   string             `json:"cursor"`
+	HasMore  bool               `json:"hasMore"`
+}
+
+// listRequests reads back what an endpoint has captured. An empty `since` is
+// the browser's call, with no cursor.
+func listRequests(t *testing.T, id, search, since string) requestListing {
+	t.Helper()
+
+	response := get(t, "/api/endpoints/"+id+"/requests?search="+search+
+		"&since="+url.QueryEscape(since))
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	var payload requestListing
+	require.NoError(t, json.Unmarshal([]byte(bodyOf(t, response)), &payload))
+	return payload
+}
+
+func capturedRequests(t *testing.T, id, search string) []database.Request {
+	t.Helper()
+	return listRequests(t, id, search, "").Requests
+}
+
+func listedTotal(t *testing.T, id, search string) int64 {
+	t.Helper()
+	return listRequests(t, id, search, "").Total
 }

--- a/src/pages.go
+++ b/src/pages.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log/slog"
+	"maps"
 
 	"github.com/atrox/haikunatorgo/v2"
 	"github.com/gofiber/fiber/v3"
@@ -11,11 +12,6 @@ import (
 // whole site: an unfurled link is a link to httphq, whichever page it points at.
 const socialImagePath = "/social-card.png"
 
-// Every surface that states how long a capture lives renders RetentionPhrase
-// rather than typing a figure, so moving retentionWindow moves the promise
-// wherever the pages make it. Prose that quoted its own number would go on
-// quoting the old one, and a reader has no way to tell.
-
 // pageBaseURL is the scheme+host a rendered page is being served from, used to
 // build the absolute URLs that canonical and Open Graph tags require. It tracks
 // the request rather than a configured hostname so a self-hosted deployment
@@ -24,64 +20,90 @@ func pageBaseURL(c fiber.Ctx) string {
 	return c.Scheme() + "://" + string(c.Request().Host())
 }
 
-// pageMeta builds the head fields layouts/main renders for a public page.
+// pageMeta builds the head fields layouts/main renders. Every page goes through
+// it, so no surface can quietly ship without the tags the others carry.
+//
 // Absolute URLs are derived from the request, so every deployment advertises
 // its own host. The social image carries its content hash for the same reason
 // the stylesheet does, so a card cached against one deploy is not served beside
 // the next one's markup.
-func pageMeta(c fiber.Ctx, assets *assetIndex, title, description, path string) fiber.Map {
+//
+// Every surface that states how long a capture lives renders RetentionPhrase
+// rather than typing a figure, so moving retentionWindow moves the promise
+// wherever the pages make it. Prose that quoted its own number would go on
+// quoting the old one, and a reader has no way to tell.
+//
+// An empty canonicalPath leaves the canonical and og:url tags off, which is
+// what a page that is not the shared address for its content wants.
+func pageMeta(c fiber.Ctx, assets *assetIndex, title, description, canonicalPath string) fiber.Map {
 	base := pageBaseURL(c)
-	return fiber.Map{
+	meta := fiber.Map{
 		"Title":           title,
 		"Description":     description,
-		"Canonical":       base + path,
 		"SocialImage":     base + assets.url(socialImagePath),
 		"RetentionPhrase": retentionPhrase(retentionWindow),
+	}
+	if canonicalPath != "" {
+		meta["Canonical"] = base + canonicalPath
+	}
+	return meta
+}
+
+// renderPage answers with a page that reads the same for every visitor, so its
+// head fields are the whole of it. A surface carrying state of its own builds
+// on pageMeta directly instead.
+func renderPage(assets *assetIndex, view, title, description, canonicalPath string) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		return c.Render(view, pageMeta(c, assets, title, description, canonicalPath))
 	}
 }
 
 func renderIndex(assets *assetIndex) fiber.Handler {
-	return func(c fiber.Ctx) error {
-		return c.Render("index", pageMeta(c, assets,
-			"httphq: inspect HTTP requests in real time",
-			"Generate a unique URL, point any client at it, and watch every request arrive: method, headers, body, query string, client IP. No account, free forever.",
-			"/"))
-	}
+	return renderPage(assets, "index",
+		"httphq: inspect HTTP requests in real time",
+		"Generate a unique URL, point any client at it, and watch every request arrive: method, headers, body, query string, client IP. No account, free forever.",
+		"/")
 }
 
 func renderContact(assets *assetIndex) fiber.Handler {
-	return func(c fiber.Ctx) error {
-		return c.Render("contact", pageMeta(c, assets,
-			"Contact | httphq",
-			"Found a bug, have an idea, or want to say hi? Get in touch with the people who build httphq.",
-			"/contact"))
-	}
+	return renderPage(assets, "contact",
+		"Contact | httphq",
+		"Found a bug, have an idea, or want to say hi? Get in touch with the people who build httphq.",
+		"/contact")
 }
 
 // renderEndpoint renders the live capture stream for one endpoint. It carries no
 // canonical URL: endpoint pages are per-user surfaces excluded by robots.txt,
-// and pointing them at a shared URL would be a lie.
-func renderEndpoint(c fiber.Ctx) error {
-	endpointID := c.Params("endpoint")
-	endpointURL, websocketURL, apiURL := endpointURLs(
-		c.Scheme(), string(c.Request().Host()), endpointID)
-	retention := retentionPhrase(retentionWindow)
-	return c.Render("endpoint", fiber.Map{
-		"Title":                endpointID + " | httphq",
-		"Description":          "Live capture stream for " + endpointID + ". Requests sent to this endpoint appear here in real time and are deleted after " + retention + ".",
-		"AppScripts":           true,
-		"EndpointID":           endpointID,
-		"EndpointURL":          endpointURL,
-		"EndpointWebSocketURL": websocketURL,
-		"RetentionPhrase":      retention,
-		// The page drops captures from its own list once they age out, so it
-		// needs the window as a number rather than as the prose it renders.
-		"RetentionSeconds": int(retentionWindow.Seconds()),
-		// Rendered rather than written by hand so the prompt quotes this
-		// deployment's own URLs and the limits actually in force.
-		"AgentPrompt": agentPrompt(
-			endpointURL, apiURL, productionRequestsPerMinute, retentionWindow),
-	})
+// and pointing them at a shared URL would be a lie. It still advertises the
+// social image, because a capture URL gets pasted into chat clients that unfurl
+// it and a card is what they render.
+func renderEndpoint(assets *assetIndex) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		endpointID := c.Params("endpoint")
+		endpointURL, websocketURL, apiURL := endpointURLs(
+			c.Scheme(), string(c.Request().Host()), endpointID)
+		retention := retentionPhrase(retentionWindow)
+
+		page := fiber.Map{
+			"AppScripts":           true,
+			"EndpointID":           endpointID,
+			"EndpointURL":          endpointURL,
+			"EndpointWebSocketURL": websocketURL,
+			// The page drops captures from its own list once they age out, so it
+			// needs the window as a number rather than as the prose it renders.
+			"RetentionSeconds": int(retentionWindow.Seconds()),
+			// Rendered rather than written by hand so the prompt quotes this
+			// deployment's own URLs and the limits actually in force.
+			"AgentPrompt": agentPrompt(
+				endpointURL, apiURL, productionRequestsPerMinute, retentionWindow),
+		}
+		maps.Copy(page, pageMeta(c, assets,
+			endpointID+" | httphq",
+			"Live capture stream for "+endpointID+". Requests sent to this endpoint appear here in real time and are deleted after "+retention+".",
+			""))
+
+		return c.Render("endpoint", page)
+	}
 }
 
 // createEndpoint mints an endpoint ID and sends the caller to its page. The ID

--- a/src/pages_test.go
+++ b/src/pages_test.go
@@ -9,29 +9,62 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Every page's head fields come from pageMeta, so what it emits is what the
+// whole site advertises. These cover the fields that have to hold across all of
+// them; a page's own copy is asserted beside its handler below.
+func TestPageMeta(t *testing.T) {
+	pages := map[string]string{
+		"index":    "/",
+		"contact":  "/contact",
+		"endpoint": "/" + endpointID(t),
+	}
+
+	// The card carries a content hash, so it is matched by prefix rather than
+	// in full: pinning the whole URL would pin the bytes of the image.
+	t.Run("every page advertises the social card", func(t *testing.T) {
+		for name, path := range pages {
+			t.Run(name, func(t *testing.T) {
+				assert.Contains(t, bodyOf(t, get(t, path)),
+					`<meta property="og:image" content="http://example.com/social-card.png?v=`)
+			})
+		}
+	})
+
+	// The URLs track the request rather than a configured hostname, so a
+	// self-hosted deployment advertises itself instead of httphq.com.
+	t.Run("absolute URLs name the host that served the page", func(t *testing.T) {
+		for name, path := range pages {
+			t.Run(name, func(t *testing.T) {
+				assert.NotContains(t, bodyOf(t, get(t, path)), "httphq.com")
+			})
+		}
+	})
+
+	// The window is a promise, so it is rendered from the constant the sweep
+	// uses rather than typed into the copy of each page that states it.
+	// The contact page is not in this list because it never states the window.
+	t.Run("the pages that state the retention window render it from one constant", func(t *testing.T) {
+		for _, name := range []string{"index", "endpoint"} {
+			t.Run(name, func(t *testing.T) {
+				assert.Contains(t, prose(t, get(t, pages[name])), "deleted after 4 hours")
+			})
+		}
+	})
+}
+
 func TestRenderIndex(t *testing.T) {
-	t.Run("renders with its canonical and social tags", func(t *testing.T) {
+	t.Run("renders with its title and canonical tag", func(t *testing.T) {
 		response := get(t, "/")
 		body := bodyOf(t, response)
 
 		assert.Equal(t, http.StatusOK, response.StatusCode)
 		assert.Contains(t, body, "<title>httphq: inspect HTTP requests in real time</title>")
 		assert.Contains(t, body, `<link rel="canonical" href="http://example.com/" />`)
-		// Matched by prefix rather than in full: the card carries a content
-		// hash, so pinning the whole URL would pin the bytes of the image.
-		assert.Contains(t, body, `<meta property="og:image" content="http://example.com/social-card.png?v=`)
-	})
-
-	// The window is a promise the landing page makes before a visitor points
-	// traffic at a public URL, so it is rendered from the constant the sweep
-	// uses rather than typed into the copy.
-	t.Run("states the retention window", func(t *testing.T) {
-		assert.Contains(t, prose(t, get(t, "/")), "deleted after 4 hours")
 	})
 }
 
 func TestRenderContact(t *testing.T) {
-	t.Run("renders with its canonical tag", func(t *testing.T) {
+	t.Run("renders with its title and canonical tag", func(t *testing.T) {
 		response := get(t, "/contact")
 		body := bodyOf(t, response)
 
@@ -52,24 +85,19 @@ func TestRenderEndpoint(t *testing.T) {
 	})
 
 	// The page expires captures out of its own list, so it needs the window as
-	// a number. Rendering it from the same constant the sweep uses is what keeps
-	// the two from drifting.
-	t.Run("carries the retention window as a number and as prose", func(t *testing.T) {
-		id := endpointID(t)
-
-		assert.Contains(t, bodyOf(t, get(t, "/"+id)), `data-retention-seconds="14400"`)
-		assert.Contains(t, prose(t, get(t, "/"+id)), "deleted after 4 hours")
+	// a number as well as the prose every page states.
+	t.Run("carries the retention window as a number", func(t *testing.T) {
+		assert.Contains(t, bodyOf(t, get(t, "/"+endpointID(t))), `data-retention-seconds="14400"`)
 	})
 
 	// The prompt is built from the request, so a self-hosted deployment hands
-	// out its own URLs rather than httphq.com's.
+	// out its own URLs and the limits actually in force.
 	t.Run("carries an agent prompt for this host", func(t *testing.T) {
 		id := endpointID(t)
 		body := bodyOf(t, get(t, "/"+id))
 
 		assert.Contains(t, body, "http://example.com/api/endpoints/"+id+"/requests")
 		assert.Contains(t, body, "150 requests per minute")
-		assert.NotContains(t, body, "httphq.com")
 	})
 
 	// robots.txt excludes endpoint pages, so a canonical URL pointing them at a
@@ -78,6 +106,7 @@ func TestRenderEndpoint(t *testing.T) {
 		body := bodyOf(t, get(t, "/"+endpointID(t)))
 
 		assert.NotContains(t, body, `rel="canonical"`)
+		assert.NotContains(t, body, `property="og:url"`)
 	})
 }
 

--- a/src/platform.go
+++ b/src/platform.go
@@ -32,7 +32,7 @@ var omittedHeaders = [...]string{
 
 // platformConfig describes how a hosting platform exposes request metadata:
 // which header carries the real client IP, and which vendor headers it adds
-// that should be hidden from captured requests — users inspect their own
+// that should be hidden from captured requests. Users inspect their own
 // traffic and shouldn't have to care which provider sits in front of httphq.
 type platformConfig struct {
 	ipHeader    string   // header with the real client IP; "" = TCP peer
@@ -106,9 +106,9 @@ func resolveClientIP(c fiber.Ctx) string {
 	return ""
 }
 
-// omitHeader reports whether a captured-request header is infrastructure noise
-// — a generic forwarding header or a vendor header added by the configured
-// PLATFORM — and so should be hidden from the user.
+// omitHeader reports whether a captured-request header is infrastructure
+// noise, meaning a generic forwarding header or a vendor header added by the
+// configured PLATFORM, and so should be hidden from the user.
 func omitHeader(name string) bool {
 	for _, h := range omittedHeaders {
 		if strings.EqualFold(name, h) {

--- a/src/platform_test.go
+++ b/src/platform_test.go
@@ -9,16 +9,6 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// withPlatform points the process-wide platform config at name for the duration
-// of one test. Client-IP resolution and header stripping both read that global,
-// so a test that changes it has to put it back.
-func withPlatform(t *testing.T, name string) {
-	t.Helper()
-	previous := currentPlatform
-	currentPlatform = resolvePlatform(name)
-	t.Cleanup(func() { currentPlatform = previous })
-}
-
 // contextWith builds a request context from peerIP carrying the given headers,
 // so a test can exercise the header-reading helpers without a live server.
 func contextWith(t *testing.T, app *fiber.App, peerIP string, headers map[string]string) fiber.Ctx {

--- a/src/requestlog.go
+++ b/src/requestlog.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"log/slog"
+	"net/http"
 	"regexp"
 	"time"
 
@@ -25,8 +27,25 @@ var probePaths = map[string]struct{}{
 	"/api/health": {},
 }
 
-// requestLogger assigns each request a correlation ID — reusing a valid
-// inbound X-Request-Id, otherwise minting one — exposes it on the context and
+// responseStatus is the status the caller will be answered with.
+//
+// A handler that refuses a request returns an error rather than writing a
+// status, and Fiber's error handler turns that into a response only after this
+// middleware has unwound. Reading the response directly at that point yields
+// the untouched default, so every refusal would be logged as a success.
+func responseStatus(c fiber.Ctx, err error) int {
+	if err == nil {
+		return c.Response().StatusCode()
+	}
+	var fiberError *fiber.Error
+	if errors.As(err, &fiberError) {
+		return fiberError.Code
+	}
+	return http.StatusInternalServerError
+}
+
+// requestLogger assigns each request a correlation ID, reusing a valid inbound
+// X-Request-Id and otherwise minting one. It exposes that ID on the context and
 // the X-Request-Id response header, and emits one structured access-log line.
 // Request headers and bodies are never logged, and the path is logged without
 // its query string.
@@ -52,7 +71,7 @@ func requestLogger(c fiber.Ctx) error {
 	attrs := []slog.Attr{
 		slog.String("http.request.method", c.Method()),
 		slog.String("url.path", c.Path()),
-		slog.Int("http.response.status_code", c.Response().StatusCode()),
+		slog.Int("http.response.status_code", responseStatus(c, err)),
 		slog.Float64("http.server.request.duration", time.Since(start).Seconds()),
 	}
 	if err != nil {

--- a/src/requestlog_test.go
+++ b/src/requestlog_test.go
@@ -1,12 +1,48 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// accessLogFor drives one request with the process logger pointed at a buffer
+// and returns the access-log line it produced. The logger is process-wide, so
+// it is restored before the next test reads it.
+//
+// The handler is a plain JSON handler rather than the one Init installs, so
+// levels appear as slog spells them. Rendering them lower-case is the logging
+// package's job and is covered there.
+func accessLogFor(t *testing.T, spec testRequest) map[string]any {
+	t.Helper()
+
+	var out bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&out, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	do(t, spec)
+
+	// A request may log more than its access line, so the line is found by its
+	// message rather than by position.
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		var record map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &record))
+		if record["msg"] == "request" {
+			return record
+		}
+	}
+	t.Fatalf("no access-log line in %q", out.String())
+	return nil
+}
 
 // An inbound request ID is echoed and stamped on every log line, so its shape
 // bounds what an untrusted caller can put in the logs.
@@ -77,9 +113,35 @@ func TestRequestLogger(t *testing.T) {
 	})
 }
 
+// The status is what an operator reads a log for, and it is the one field the
+// response cannot be asked for directly while a refusal is still unwinding.
+func TestResponseStatus(t *testing.T) {
+	t.Run("a served request logs the status it was answered with", func(t *testing.T) {
+		record := accessLogFor(t, testRequest{method: http.MethodGet, path: "/api/health"})
+
+		assert.Equal(t, float64(http.StatusOK), record["http.response.status_code"])
+	})
+
+	t.Run("a refused request logs its refusal, not a success", func(t *testing.T) {
+		// The socket route refuses a request that is not an upgrade, which is
+		// the shape every Fiber error takes: returned, not written.
+		record := accessLogFor(t, testRequest{
+			method: http.MethodGet, path: "/ws/purple-frog-0691",
+		})
+
+		assert.Equal(t, float64(http.StatusUpgradeRequired), record["http.response.status_code"])
+	})
+
+	t.Run("a handler that writes its own status is logged unchanged", func(t *testing.T) {
+		record := accessLogFor(t, testRequest{method: http.MethodGet, path: "/no/such/page"})
+
+		assert.Equal(t, float64(http.StatusNotFound), record["http.response.status_code"])
+	})
+}
+
+// Probe traffic is constant and says nothing, so it logs at debug and stays out
+// of production logs. Everything else has to remain visible.
 func TestProbePaths(t *testing.T) {
-	// Probe traffic is constant and says nothing, so it logs at debug and stays
-	// out of production logs. Everything else has to remain visible.
 	t.Run("only probe traffic is demoted", func(t *testing.T) {
 		_, isProbe := probePaths["/api/health"]
 		assert.True(t, isProbe)
@@ -88,5 +150,25 @@ func TestProbePaths(t *testing.T) {
 			_, demoted := probePaths[path]
 			assert.Falsef(t, demoted, "%s carries real traffic and must be logged at info", path)
 		}
+	})
+
+	t.Run("a probe logs below the level a production deployment records", func(t *testing.T) {
+		record := accessLogFor(t, testRequest{method: http.MethodGet, path: "/api/health"})
+
+		assert.Equal(t, slog.LevelDebug.String(), record["level"])
+	})
+
+	t.Run("real traffic stays visible", func(t *testing.T) {
+		record := accessLogFor(t, testRequest{method: http.MethodGet, path: "/contact"})
+
+		assert.Equal(t, slog.LevelInfo.String(), record["level"])
+	})
+
+	t.Run("a refusal is loud", func(t *testing.T) {
+		record := accessLogFor(t, testRequest{
+			method: http.MethodGet, path: "/ws/purple-frog-0691",
+		})
+
+		assert.Equal(t, slog.LevelError.String(), record["level"])
 	})
 }

--- a/src/security.go
+++ b/src/security.go
@@ -35,9 +35,9 @@ func contentSecurityPolicy(allowDesignTooling bool) string {
 // securityHeaders stamps the fixed security headers onto every response.
 //
 // They are set on the way out, after the rest of the chain has run. A handler
-// is free to reset the response it is building — the static middleware does
-// exactly that when a path resolves to a directory rather than a file — and a
-// header set on the way in would go with it. These have to hold for every
+// is free to reset the response it is building, as the static middleware does
+// when a path resolves to a directory rather than a file, and a header set on
+// the way in would go with it. These have to hold for every
 // response the app emits, so they are written where nothing downstream can
 // discard them.
 func securityHeaders(policy string) fiber.Handler {

--- a/src/security_test.go
+++ b/src/security_test.go
@@ -9,11 +9,24 @@ import (
 )
 
 // The headers are set by middleware rather than per route, so the assertion
-// that matters is that no surface can be reached without them: a page, an API
-// route, a probe and the fallthrough 404 all have to carry them.
+// that matters is that no surface can be reached without them. The paths below
+// are one of each response shape the app produces: a rendered page, a file from
+// the static directory, an API route, the fallthrough 404, and a request a
+// handler refuses by returning an error rather than writing a status. The
+// static and refused responses are the ones that matter most, because both are
+// built by something that discards a response set on the way in.
 func TestSecurityHeaders(t *testing.T) {
 	t.Run("every response carries them", func(t *testing.T) {
-		for _, path := range []string{"/", "/contact", "/api/health", "/no/such/page"} {
+		responseShapes := []string{
+			"/",
+			"/contact",
+			"/robots.txt",
+			"/api/health",
+			"/no/such/page",
+			"/ws/purple-frog-0691",
+		}
+
+		for _, path := range responseShapes {
 			t.Run(path, func(t *testing.T) {
 				response := get(t, path)
 

--- a/src/sockets_test.go
+++ b/src/sockets_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,5 +63,26 @@ func TestSocketRegistry(t *testing.T) {
 		registry.remove("uuid-never-seen")
 
 		assert.Equal(t, 1, registry.count())
+	})
+}
+
+// The socket is the only route that answers something other than an HTTP
+// response, so the guard in front of it decides what an ordinary caller gets.
+func TestRegisterWebSockets(t *testing.T) {
+	t.Run("a plain request is refused rather than served", func(t *testing.T) {
+		response := get(t, "/ws/purple-frog-0691")
+
+		assert.Equal(t, http.StatusUpgradeRequired, response.StatusCode)
+	})
+
+	// The guard is mounted on the prefix, so it answers before the route can
+	// reject the ID. A malformed ID is refused for the wrong-looking reason,
+	// which is fine: neither answer reveals whether the endpoint exists.
+	t.Run("the guard covers the whole socket prefix", func(t *testing.T) {
+		for _, path := range []string{"/ws", "/ws/", "/ws/Not_A_Valid_ID"} {
+			t.Run(path, func(t *testing.T) {
+				assert.Equal(t, http.StatusUpgradeRequired, get(t, path).StatusCode)
+			})
+		}
 	})
 }

--- a/src/views/endpoint.html
+++ b/src/views/endpoint.html
@@ -450,7 +450,6 @@
         </header>
 
         <div class="space-y-4 p-4 sm:p-5">
-          <!-- Details -->
           <div data-test="request-details">
             <h3 class="region-label mb-2">Details</h3>
             <dl class="text-sm">
@@ -484,7 +483,6 @@
             </dl>
           </div>
 
-          <!-- Headers -->
           <div data-test="request-headers">
             <div class="flex items-center justify-between mb-2">
               <h3 class="region-label">
@@ -531,7 +529,6 @@
           </div>
         </div>
 
-        <!-- Query string -->
         <div data-test="query-string" class="px-4 sm:px-5 pb-3">
           <div class="flex items-center justify-between mb-1">
             <h3 class="region-label">Query string</h3>
@@ -555,7 +552,6 @@
           </template>
         </div>
 
-        <!-- Body -->
         <div data-test="request-body" class="px-4 sm:px-5 pb-4 sm:pb-5">
           <div class="flex items-center justify-between mb-1">
             <h3 class="region-label">

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -108,7 +108,6 @@
     </p>
   </section>
 
-  <!-- Common use cases -->
   <section
     data-test="use-cases"
     class="w-full max-w-4xl mx-auto pb-8 sm:pb-12 text-left"


### PR DESCRIPTION
A pass over everything pushed in the recent work window: test organisation, the gaps that organisation exposed, obvious duplication, and a comment and docs tour. Two real defects turned up while writing the tests and are fixed here.

## Defects found and fixed

**Every refused request was logged as a `200`.** A handler that refuses returns an error rather than writing a status, and Fiber's error handler builds the response only after the access-log middleware has unwound. The middleware read the response directly, so a socket upgrade refused with `426` appeared in the log as a success. `responseStatus` now derives it from the error.

**An oversized body left a bodyless capture behind.** The body limit is enforced around the handler, not in front of it, so a request declaring more than 1 MiB reached `captureRequest` with its body already dropped, was stored, and was then answered `413`. The caller was told no and the endpoint's owner was left with a capture claiming a sender had posted nothing. `docs/api.md` said larger captures are rejected; now they are.

**The browser suite raced the page it was testing.** The per-test gate waited on the endpoint URL, which is server-rendered and on screen before Alpine runs, so the comment claiming it waited for the page to mount was not true of the element it waited on. Under parallel workers this failed in clusters (up to 8 tests in a run), on `master` as well as here. It now gates on the first thing the mounted component draws. Local workers are also bounded, because every page load pulls Alpine and the highlighter from public CDNs with no shared cache.

**The body-limit e2e test asserted an unobservable status.** The server answers `413` and closes without draining the rest of the body, so a client still writing sees the reset instead of the reply. It now accepts either and asserts what holds regardless: nothing was stored.

## Organisation

Shared fixtures moved to `harness_test.go`, where a fixture used by more than one subject belongs: `withPlatform` from `platform_test.go`, the listing reader from `api_test.go`. The store helper named `uuidsFor` collided with a `socketRegistry` method answering a different question, and is now `storedUUIDs`. Delete tests follow `api.go`'s order; the asset helper sits above its tests, as helpers do elsewhere.

## Gaps closed

- The socket route had no test at all, though every route carrying an `:endpoint` parameter is meant to be behind the validator.
- Security headers are set on the way out because a handler can discard a response set on the way in, and neither response that does so was covered: a static file, and a request refused by returning an error.
- A header sent twice reaching storage as a list, and the curl spoof, both only had tests against hand-built maps, never off the wire.
- Access-log levels (debug for a probe, info for traffic, error for a refusal) had no test.
- Reload versions a path the startup pass never hashed, which is why the template check exists. That divergence is now stated in a test.
- The rendered payload size and result count were on screen and unasserted.

## Duplication

`pageMeta` now builds every page's head fields, `renderEndpoint` included, with the canonical path optional. That closes a gap the layout already assumed: it says capture URLs get pasted into clients that unfurl them, but endpoint pages carried no social image and unfurled as a bare summary. Seven database queries spelled the same error-logging block; it is one helper. The endpoint component looked its store up by name nine times. The e2e base URL was spelled three times.

## Lint, types and prose

ESLint, `tsc --noEmit`, `go vet` and prettier are all clean, with zero `eslint-disable`, zero `@ts-ignore`/`@ts-expect-error` and zero `any`. Two type assertions remain, both confined to the harness at the JSON boundary where `JSON.parse` and `APIResponse.json` return `any`; the listing shape moved there so no test declares its own.

Twenty em dashes removed by rewriting the clause. Comments that restated the line below them are gone, replaced by the reason where there was one. No spelling errors found; British spelling is consistent throughout.

## Verification

209 Go subtests and 71 Playwright tests pass, the latter across six consecutive runs after the flake fix. Beyond the suites, every route was driven directly (methods, body, query, headers, search, cursor round trip, malformed `since`, repeated headers, header stripping, curl spoof, body limit at and over, both deletes, ID validation, security headers, static assets, head tags) and every touched surface driven in Chrome: home, contact, and an endpoint page through live WebSocket arrivals, JSON/XML/multipart body rendering, the send panel including its malformed-header path, the agent prompt, copy feedback, HAR export, filtering, both delete flows, pagination, retention pruning, and a mobile viewport. No console errors, no failed requests.

## One note

`port` in `src/application.go` is a constant and 8080 was held by another project here, so the suites were run against a temporarily changed constant. It is back at 8080 in this branch; `docs/scripts.md` now records how to do the same, and `HTTPHQ_BASE_URL` points the browser suite at it.

Chrome reports a pre-existing advisory on the send panel's four fields, which carry no `id` or `name`. They are each wrapped in their own `<label>` and the form never submits, so this is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JX88ivRLj8Q6ABcFk3LAuf