### PR TITLE
Record the copy convention, and correct the package layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for agents and contributors working in this repository.
 
 ## Code layout
 
-`src` is one `main` package split by concern, one file per subject with its
+`src` is a `main` package split by concern, one file per subject with its
 tests beside it: `application.go` (wiring and entry point), `platform.go`
 (client IP and header stripping), `endpoint.go` (endpoint IDs and URLs),
 `capture.go` (the capture handler), `api.go` (the JSON API), `pages.go` (page
@@ -12,6 +12,10 @@ rendering), `agent.go` (the prompt an endpoint page hands to a coding agent),
 `assets.go` (content-hashed asset URLs), `security.go` (CSP and security
 headers), `sockets.go` (the live feed), `requestlog.go` (correlation IDs and
 the access log).
+
+Two subpackages sit beneath it: `database` (the SQLite connection) and
+`logging` (the slog handler and its sensitive-key redaction). `styles` and
+`views` hold CSS and HTML templates rather than Go.
 
 A test file covers one subject, is named after it, and names each suite after
 what it exercises, so a handler's tests are found beside the handler. The one
@@ -39,6 +43,13 @@ them so they still make sense in a year.
   new surfaces are safe").
 - Keep comments generic and reusable, especially in shared helpers and test
   fixtures.
+
+## User-facing copy names the format, not the consumer
+
+Button labels, tooltips and empty-state copy name the format or the action
+(`Copy request`, `Copy all (N)`), never a consumer such as agents or LLMs. The
+constraint is on product copy only; commit messages and docs may mention agents
+freely.
 
 ## Client IP is a trust decision
 


### PR DESCRIPTION
Two AGENTS.md corrections, no code changes.

## Copy convention

Documents a product-copy rule that until now only lived in a local memory store, so it never reached a fresh clone or a teammate: user-facing labels name the format or the action (`Copy request`, `Copy all (N)`), never a consumer such as agents or LLMs. The constraint is on product copy only; commit messages and docs may mention agents freely.

Verified against the tree: those two labels are what ship today, and no "Copy for agents" wording survives.

## Package layout

`## Code layout` claimed "`src` is one `main` package split by concern". The code contradicts that:

- `src/database` is `package database`, present since 2022
- `src/logging` is `package logging`, added 2026-05-15
- `src/styles` and `src/views` hold CSS and HTML templates, not Go

The paragraph now says `src` is *a* `main` package and names the two subpackages and the two asset directories beneath it.

## Everything else checked

The rest of AGENTS.md was audited claim by claim and left alone: `newApplication`, `TestMain` in `harness_test.go`, `PLATFORM`, `port = 8080`, the slog and OpenTelemetry field names, `X-Request-Id`, the `/api/health` probe path, sensitive-key redaction, and `file:local.db` with no `VOLUME` behind the ephemerality claim.

One thing left undone: `docs/api.md` and `docs/scripts.md` are linked only from README.md, so an agent reading AGENTS.md never learns they exist.