### PR TITLE
Cut cyclomatic complexity and close the test coverage gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,20 @@ the fixtures shared by every test that drives a real request.
 drive real requests through it without a listening socket. Anything that pulls
 configuration out of the environment belongs in `main`, not in a handler.
 
+## The Playwright suite covers screens and page scripts separately
+
+`e2e/tests` holds one spec per subject. A `*-screen.spec.ts` drives a screen
+through captured traffic and asserts what a reader ends up seeing.
+`render-body.spec.ts` and `page-helpers.spec.ts` drive the browser scripts
+directly through `loadPageScripts`, because traffic cannot express everything
+those scripts handle: the server parses and re-serialises a multipart body
+before storing it, so several part shapes a client can put on the wire never
+reach the page intact.
+
+Fixtures used by more than one spec live in `tests/support/harness.ts`, which is
+also the one place a type is asserted rather than proven, at the `JSON.parse`
+and `response.json()` boundaries.
+
 ## Comments
 
 Comments describe what the code does now and warn about non-obvious constraints

--- a/e2e/tests/endpoint-screen.spec.ts
+++ b/e2e/tests/endpoint-screen.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from "@playwright/test";
 import {
   captureUrl,
   newEndpointId,
+  newestBody,
+  newestBodyText,
   pruneExpiredCaptures,
   readClipboard,
   readClipboardJson,
@@ -150,7 +152,7 @@ test.describe("Endpoint screen", () => {
     }) => {
       await send(request, endpointUrl, { method: "GET" });
       await expect(
-        page.locator('[data-test="request-body"]').first(),
+        newestBody(page),
       ).toContainText("None");
     });
 
@@ -175,7 +177,7 @@ test.describe("Endpoint screen", () => {
       request,
     }) => {
       await send(request, endpointUrl, { data: "a".repeat(2048) });
-      const body = page.locator('[data-test="request-body"]').first();
+      const body = newestBody(page);
 
       await expect(body).toContainText("2.0 KB");
     });
@@ -274,7 +276,7 @@ test.describe("Endpoint screen", () => {
         data: { hello: "world", arr: [1, 2, 3] },
         headers: { "Content-Type": "application/json" },
       });
-      const body = page.locator('[data-test="request-body"]').first();
+      const body = newestBody(page);
       // Pretty-printed → contains a newline and 2-space indent.
       const text = await body.locator("pre").innerText();
       expect(text).toContain('"hello": "world"');
@@ -289,7 +291,7 @@ test.describe("Endpoint screen", () => {
         data: "<root><a>1</a></root>",
         headers: { "Content-Type": "application/xml" },
       });
-      const body = page.locator('[data-test="request-body"]').first();
+      const body = newestBody(page);
       const tagCount = await body.locator("pre span.hljs-tag").count();
       expect(tagCount).toBeGreaterThan(0);
     });
@@ -304,7 +306,7 @@ test.describe("Endpoint screen", () => {
         data: "<img src=x onerror=alert(1)>",
         headers: { "Content-Type": "text/html" },
       });
-      const body = page.locator('[data-test="request-body"]').first();
+      const body = newestBody(page);
       await expect(body).toContainText("onerror=alert(1)");
       await expect(body.locator("img")).toHaveCount(0);
     });
@@ -316,7 +318,7 @@ test.describe("Endpoint screen", () => {
       await request.post(endpointUrl, {
         multipart: { firstName: "Ada", role: "engineer" },
       });
-      const body = page.locator('[data-test="request-body"]').first();
+      const body = newestBody(page);
       const text = await body.locator("pre").innerText();
       expect(text).toContain('"name": "firstName"');
       expect(text).toContain('"value": "Ada"');
@@ -339,8 +341,7 @@ test.describe("Endpoint screen", () => {
           },
         },
       });
-      const body = page.locator('[data-test="request-body"]').first();
-      const text = await body.locator("pre").innerText();
+      const text = await newestBodyText(page);
       expect(text).toContain('"filename": "avatar.png"');
       expect(text).toContain('"contentType": "image/png"');
       expect(text).toMatch(/"size":\s*\d+/);
@@ -355,13 +356,40 @@ test.describe("Endpoint screen", () => {
       formData.append("tag", "red");
       formData.append("tag", "blue");
       await request.post(endpointUrl, { multipart: formData });
-      const body = page.locator('[data-test="request-body"]').first();
-      const text = await body.locator("pre").innerText();
+      const text = await newestBodyText(page);
       const tagValues = [
         ...text.matchAll(/"name": "tag",\s*\n\s*"value": "(\w+)"/g),
       ].map((m) => m[1]);
       expect(tagValues).toEqual(["red", "blue"]);
     });
+
+    // The header grammar allows a quoted boundary, and it may sit behind other
+    // parameters. Taking the quotes as part of the boundary, or reading only
+    // the first parameter, leaves nothing in the body matching the delimiter
+    // and the whole payload falls through to raw text.
+    test("parses a multipart body whose boundary is quoted", async ({
+      page,
+      request,
+    }) => {
+      const boundary = "QuotedBnd";
+      await send(request, endpointUrl, {
+        data: [
+          `--${boundary}`,
+          'Content-Disposition: form-data; name="city"',
+          "",
+          "Ghent",
+          `--${boundary}--`,
+          "",
+        ].join("\r\n"),
+        headers: {
+          "Content-Type": `multipart/form-data; charset=utf-8; boundary="${boundary}"`,
+        },
+      });
+      const text = await newestBodyText(page);
+      expect(text).toContain('"name": "city"');
+      expect(text).toContain('"value": "Ghent"');
+    });
+  });
 
     test("falls back to raw display when a multipart body has no boundary", async ({
       page,
@@ -371,10 +399,9 @@ test.describe("Endpoint screen", () => {
         data: "not-actually-parseable-multipart",
         headers: { "Content-Type": "multipart/form-data" },
       });
-      const body = page.locator('[data-test="request-body"]').first();
+      const body = newestBody(page);
       await expect(body).toContainText("not-actually-parseable-multipart");
     });
-  });
 
   test.describe("Filtering", () => {
     test("filters by request body via the search box", async ({

--- a/e2e/tests/page-helpers.spec.ts
+++ b/e2e/tests/page-helpers.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect } from "@playwright/test";
+import { loadPageScripts } from "./support/harness";
+
+/**
+ * The helpers the page scripts share, driven directly. Each is a pure function
+ * with edges the screens only reach by accident: a count of exactly one, a body
+ * sitting on a unit boundary, a header line one character away from valid.
+ */
+
+test.describe("Page helpers", () => {
+  test.beforeEach(async ({ page }) => {
+    await loadPageScripts(page);
+  });
+
+  test.describe("Byte length", () => {
+    // Everything that reports a size measures what was stored, which is bytes.
+    // Counting characters would under-report every payload that is not ASCII.
+    test("counts bytes rather than characters", async ({ page }) => {
+      const lengths = await page.evaluate(() =>
+        ["", "abc", "naïve €", "🙂"].map((text) => window.byteLength(text)),
+      );
+
+      expect(lengths).toEqual([0, 3, 10, 4]);
+    });
+  });
+
+  test.describe("Byte formatting", () => {
+    test("changes unit at each threshold", async ({ page }) => {
+      const formatted = await page.evaluate(() =>
+        [0, 1023, 1024, 1536, 1_048_576, 5_242_880].map((bytes) =>
+          window.formatBytes(bytes),
+        ),
+      );
+
+      expect(formatted).toEqual([
+        "0 B",
+        "1023 B",
+        "1.0 KB",
+        "1.5 KB",
+        "1.0 MB",
+        "5.0 MB",
+      ]);
+    });
+  });
+
+  test.describe("Pluralising", () => {
+    // A panel that says "1 requests" reads as a defect in the thing being
+    // counted rather than in the sentence counting it.
+    test("a count of one keeps the noun singular", async ({ page }) => {
+      const phrases = await page.evaluate(() =>
+        [0, 1, 2].map((count) => window.pluralize(count, "request")),
+      );
+
+      expect(phrases).toEqual(["0 requests", "1 request", "2 requests"]);
+    });
+  });
+
+  /**
+   * The send panel's header field. A malformed line is reported rather than
+   * dropped: silently discarding a line that is one typo away from an
+   * Authorization header, then reporting success, sends the user chasing an
+   * auth failure that was never in their request.
+   */
+  test.describe("Header lines", () => {
+    const parse = (page: Parameters<typeof loadPageScripts>[0], text: string) =>
+      page.evaluate((source) => window.parseHeaderLines(source), text);
+
+    test("splits each line on its first colon", async ({ page }) => {
+      const parsed = await parse(
+        page,
+        "Content-Type: application/json\nX-Token: abc",
+      );
+
+      expect(parsed.headers).toEqual({
+        "Content-Type": "application/json",
+        "X-Token": "abc",
+      });
+      expect(parsed.invalid).toEqual([]);
+    });
+
+    test("whitespace around a key and its value is trimmed", async ({
+      page,
+    }) => {
+      const parsed = await parse(page, "   X-Token   :   abc   ");
+
+      expect(parsed.headers).toEqual({ "X-Token": "abc" });
+    });
+
+    // A colon is legal inside a value, and a URL or a timestamp carries one.
+    test("a colon inside the value is kept", async ({ page }) => {
+      const parsed = await parse(page, "X-Origin: https://example.com:8443/a");
+
+      expect(parsed.headers).toEqual({
+        "X-Origin": "https://example.com:8443/a",
+      });
+    });
+
+    test("a blank line is skipped rather than reported", async ({ page }) => {
+      const parsed = await parse(page, "\n\nX-Token: abc\n   \n");
+
+      expect(parsed.headers).toEqual({ "X-Token": "abc" });
+      expect(parsed.invalid).toEqual([]);
+    });
+
+    test("a header repeated in the field keeps its last value", async ({
+      page,
+    }) => {
+      const parsed = await parse(page, "X-Token: first\nX-Token: second");
+
+      expect(parsed.headers).toEqual({ "X-Token": "second" });
+    });
+
+    // The number reported is the line the user is looking at, so a report has
+    // to count the blank lines it otherwise ignores.
+    test("a line with no colon is reported at its own line number", async ({
+      page,
+    }) => {
+      const parsed = await parse(page, "X-Token: abc\n\nnot a header at all");
+
+      expect(parsed.headers).toEqual({ "X-Token": "abc" });
+      expect(parsed.invalid).toEqual([{ line: 3, text: "not a header at all" }]);
+    });
+
+    test("a line with no key before its colon is reported", async ({
+      page,
+    }) => {
+      const parsed = await parse(page, ": orphaned value");
+
+      expect(parsed.headers).toEqual({});
+      expect(parsed.invalid).toEqual([{ line: 1, text: ": orphaned value" }]);
+    });
+
+    test("every malformed line is reported, not just the first", async ({
+      page,
+    }) => {
+      const parsed = await parse(page, "one\ntwo\nX-Token: abc");
+
+      expect(parsed.invalid).toEqual([
+        { line: 1, text: "one" },
+        { line: 2, text: "two" },
+      ]);
+    });
+
+    test("an empty field yields no headers and no complaints", async ({
+      page,
+    }) => {
+      const parsed = await parse(page, "");
+
+      expect(parsed.headers).toEqual({});
+      expect(parsed.invalid).toEqual([]);
+    });
+  });
+});

--- a/e2e/tests/render-body.spec.ts
+++ b/e2e/tests/render-body.spec.ts
@@ -1,0 +1,238 @@
+import { test, expect } from "@playwright/test";
+import { loadPageScripts } from "./support/harness";
+
+/**
+ * The body renderer's own contract, driven directly rather than through a
+ * capture. Everything asserted here is a shape the endpoint screen cannot
+ * stage: the server parses and re-serialises a multipart body before storing
+ * it, so a part with no name, a part framed with bare LF, or a part whose
+ * headers never close is normalised away or refused before the page sees it.
+ * The parser still has to answer for those, because the stored body is not the
+ * only thing it is ever handed.
+ */
+
+/**
+ * Undoes the escaping the renderer applies on its way onto the page. No
+ * highlighter is loaded here, so a rendered body is its text with the five HTML
+ * characters escaped, and reversing that recovers what was rendered.
+ */
+const unescapeHtml = (html: string) =>
+  html
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+
+const BOUNDARY = "SpecBnd";
+
+/** A multipart body from its parts, framed with the given line ending. */
+const multipart = (parts: string[], eol = "\r\n") =>
+  parts
+    .map((part) => `--${BOUNDARY}${eol}${part}`)
+    .concat(`--${BOUNDARY}--${eol}`)
+    .join("");
+
+const contentType = (value: string) => ({ "Content-Type": value });
+
+test.describe("Body renderer", () => {
+  test.beforeEach(async ({ page }) => {
+    await loadPageScripts(page);
+  });
+
+  /** Renders a body and returns what it put on the page, unescaped. */
+  const render = async (
+    page: Parameters<typeof loadPageScripts>[0],
+    body: string | null,
+    headers: Record<string, string> | null = null,
+  ) =>
+    unescapeHtml(
+      await page.evaluate(
+        ([b, h]) => window.renderBody(b, h),
+        [body, headers] as const,
+      ),
+    );
+
+  test.describe("Multipart parts", () => {
+    test("parses parts framed with bare LF as well as CRLF", async ({
+      page,
+    }) => {
+      const rendered = await render(
+        page,
+        multipart(['Content-Disposition: form-data; name="city"\n\nGhent\n'], "\n"),
+        contentType(`multipart/form-data; boundary=${BOUNDARY}`),
+      );
+
+      expect(JSON.parse(rendered)).toEqual([{ name: "city", value: "Ghent" }]);
+    });
+
+    test("a field carrying its own content type is still a field", async ({
+      page,
+    }) => {
+      const rendered = await render(
+        page,
+        multipart([
+          'Content-Disposition: form-data; name="note"\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nhello\r\n',
+        ]),
+        contentType(`multipart/form-data; boundary=${BOUNDARY}`),
+      );
+
+      // No filename means no file, whatever else the part declares about
+      // itself. A field rendered as a file would report a size and hide its
+      // value, which is the one thing the reader wanted.
+      expect(JSON.parse(rendered)).toEqual([{ name: "note", value: "hello" }]);
+    });
+
+    test("a file part is measured in bytes, not characters", async ({
+      page,
+    }) => {
+      const rendered = await render(
+        page,
+        multipart([
+          'Content-Disposition: form-data; name="f"; filename="n.txt"\r\nContent-Type: text/plain\r\n\r\nnaïve €\r\n',
+        ]),
+        contentType(`multipart/form-data; boundary=${BOUNDARY}`),
+      );
+
+      // "naïve €" is 7 characters and 10 bytes. A character count would
+      // under-report every upload that is not plain ASCII.
+      expect(JSON.parse(rendered)).toEqual([
+        {
+          name: "f",
+          filename: "n.txt",
+          contentType: "text/plain",
+          size: 10,
+        },
+      ]);
+    });
+
+    test("a file part's own bytes are never rendered", async ({ page }) => {
+      const rendered = await render(
+        page,
+        multipart([
+          'Content-Disposition: form-data; name="f"; filename="secret.bin"\r\nContent-Type: application/octet-stream\r\n\r\nSHOULD-NOT-APPEAR\r\n',
+        ]),
+        contentType(`multipart/form-data; boundary=${BOUNDARY}`),
+      );
+
+      expect(rendered).not.toContain("SHOULD-NOT-APPEAR");
+    });
+  });
+
+  /**
+   * A body that does not parse cleanly is handed to the next strategy rather
+   * than half-rendered. A partial part list would read as the whole payload,
+   * and the reader would never learn that anything was dropped.
+   */
+  test.describe("Multipart rejection", () => {
+    const rejected: Record<string, string> = {
+      "a part with no content-disposition":
+        "X-Other: 1\r\n\r\norphan\r\n",
+      "a part whose disposition names no field":
+        "Content-Disposition: form-data\r\n\r\nnameless\r\n",
+      "a part whose headers are never closed by a blank line":
+        'Content-Disposition: form-data; name="a"\r\n',
+    };
+
+    for (const [description, part] of Object.entries(rejected)) {
+      test(`${description} drops the whole body to raw text`, async ({
+        page,
+      }) => {
+        const body = multipart([part]);
+
+        const rendered = await render(
+          page,
+          body,
+          contentType(`multipart/form-data; boundary=${BOUNDARY}`),
+        );
+
+        expect(rendered).toBe(body);
+      });
+    }
+
+    test("a body with no delimiter at all falls through", async ({ page }) => {
+      const rendered = await render(
+        page,
+        "nothing here looks like a part",
+        contentType(`multipart/form-data; boundary=${BOUNDARY}`),
+      );
+
+      expect(rendered).toBe("nothing here looks like a part");
+    });
+
+    // Falling through rather than reporting a failure is what makes the chain
+    // work: a body that is not the multipart it claims to be is still shown as
+    // whatever it actually is.
+    test("a body that is JSON despite its content type is pretty-printed", async ({
+      page,
+    }) => {
+      const rendered = await render(
+        page,
+        '{"actually":"json"}',
+        contentType(`multipart/form-data; boundary=${BOUNDARY}`),
+      );
+
+      expect(rendered).toBe('{\n  "actually": "json"\n}');
+    });
+  });
+
+  test.describe("Boundary parameter", () => {
+    const bodyFor = () =>
+      multipart(['Content-Disposition: form-data; name="a"\r\n\r\n1\r\n']);
+
+    const accepted: Record<string, string> = {
+      unquoted: `multipart/form-data; boundary=${BOUNDARY}`,
+      quoted: `multipart/form-data; boundary="${BOUNDARY}"`,
+      "behind another parameter": `multipart/form-data; charset=utf-8; boundary=${BOUNDARY}`,
+      "spelled in any case": `MULTIPART/FORM-DATA; BOUNDARY=${BOUNDARY}`,
+      "padded with spaces": `multipart/form-data ;  boundary = ${BOUNDARY} `,
+    };
+
+    for (const [description, header] of Object.entries(accepted)) {
+      test(`a boundary ${description} is found`, async ({ page }) => {
+        const rendered = await render(page, bodyFor(), contentType(header));
+
+        expect(JSON.parse(rendered)).toEqual([{ name: "a", value: "1" }]);
+      });
+    }
+
+    const ignored: Record<string, string> = {
+      absent: "multipart/form-data",
+      empty: "multipart/form-data; boundary=",
+      "belonging to another media type": `multipart/mixed; boundary=${BOUNDARY}`,
+    };
+
+    for (const [description, header] of Object.entries(ignored)) {
+      test(`a boundary ${description} leaves the body raw`, async ({
+        page,
+      }) => {
+        const body = bodyFor();
+
+        const rendered = await render(page, body, contentType(header));
+
+        expect(rendered).toBe(body);
+      });
+    }
+
+    // The header may repeat, and the stored value is then a list. Reading the
+    // list itself rather than its first entry finds no boundary at all.
+    test("a repeated content-type header is read from its first value", async ({
+      page,
+    }) => {
+      const rendered = unescapeHtml(
+        await page.evaluate(
+          ([body, boundary]) =>
+            window.renderBody(body, {
+              "Content-Type": [
+                `multipart/form-data; boundary=${boundary}`,
+                "text/plain",
+              ],
+            }),
+          [bodyFor(), BOUNDARY] as const,
+        ),
+      );
+
+      expect(JSON.parse(rendered)).toEqual([{ name: "a", value: "1" }]);
+    });
+  });
+});

--- a/e2e/tests/support/harness.ts
+++ b/e2e/tests/support/harness.ts
@@ -36,10 +36,43 @@ export const requestsUrl = (endpointId: string) =>
 export const pruneExpiredCaptures = (page: Page) =>
   page.evaluate(() => window.Alpine.store("main").pruneExpired(1));
 
+/**
+ * Loads the page scripts into a page that carries none of its own, so a test
+ * can call them directly.
+ *
+ * The endpoint page only ever reaches these helpers through captured traffic,
+ * and traffic cannot carry every shape they handle: the server normalises a
+ * multipart body before storing it, so several part shapes a client can put on
+ * the wire never arrive intact. Driving the helpers here is what holds them to
+ * their whole contract rather than the part the wire can express.
+ */
+export const loadPageScripts = async (page: Page) => {
+  // The contact screen ships no JavaScript, so whatever answers afterwards came
+  // from the scripts under test and not from the page around them.
+  await page.goto("/contact");
+  for (const url of ["/index.js", "/render-body.js", "/har.js"]) {
+    await page.addScriptTag({ url });
+  }
+};
+
+/** One malformed line from the send panel's header field. */
+export type InvalidHeaderLine = { line: number; text: string };
+
 declare global {
   interface Window {
     Alpine: {
       store(name: "main"): { pruneExpired(retentionMs: number): unknown };
+    };
+    renderBody(
+      body: string | null,
+      headers: CapturedRequest["headers"] | null,
+    ): string;
+    byteLength(text: string): number;
+    formatBytes(bytes: number): string;
+    pluralize(count: number, noun: string): string;
+    parseHeaderLines(text: string): {
+      headers: Record<string, string>;
+      invalid: InvalidHeaderLine[];
     };
   }
 }
@@ -97,6 +130,18 @@ export const listRequests = async (
   const response = await request.get(requestsUrl(endpointId));
   return (await response.json()) as RequestListing;
 };
+
+/**
+ * The body panel of the newest capture on screen. Every body assertion reaches
+ * for the same panel, so the locator is spelled once rather than at each call
+ * site, and a change to the markup lands in one place.
+ */
+export const newestBody = (page: Page) =>
+  page.locator('[data-test="request-body"]').first();
+
+/** The newest capture's body as displayed text, highlighting flattened away. */
+export const newestBodyText = (page: Page) =>
+  newestBody(page).locator("pre").innerText();
 
 export const readClipboard = (page: Page) =>
   page.evaluate(() => navigator.clipboard.readText());

--- a/public/endpoint.js
+++ b/public/endpoint.js
@@ -301,8 +301,10 @@
         link.href = href;
       },
 
+      // An unrecognised method still needs a badge. It borrows HEAD's palette
+      // rather than carrying an eighth of its own, so the set stays one family.
       methodBadge(method) {
-        return METHOD_CLASSES[method] || "bg-head-wash text-head-ink";
+        return METHOD_CLASSES[method] || METHOD_CLASSES.HEAD;
       },
 
       formatTimeAgo: window.formatTimeAgo,
@@ -357,17 +359,33 @@
         this.announce(`Deleted ${window.pluralize(count, "request")}`);
       },
 
+      // Every send outcome reaches the user the same way: the status line, the
+      // flag that colours it, and the live region that speaks it.
+      _reportSend(failed, status) {
+        this.sendFailed = failed;
+        this.sendStatus = status;
+        this.announce(status);
+      },
+
+      // Where the compose form points. Leading slashes are dropped from the
+      // sub-path so "foo" and "/foo" address the same capture path.
+      _sendTarget() {
+        const path = this.sendForm.path.replace(/^\/+/, "");
+        return `/to/${this.store.endpointId}${path ? "/" + path : ""}`;
+      },
+
       async sendCustom() {
         if (!this.store.endpointId) return;
         const parsed = window.parseHeaderLines(this.sendForm.headers);
         if (parsed.invalid.length) {
-          this.sendFailed = true;
-          this.sendStatus = `Line ${parsed.invalid[0].line} is not a header: "${parsed.invalid[0].text}". Use Key: Value.`;
-          this.announce(this.sendStatus);
+          const [first] = parsed.invalid;
+          this._reportSend(
+            true,
+            `Line ${first.line} is not a header: "${first.text}". Use Key: Value.`,
+          );
           return;
         }
-        const path = this.sendForm.path.replace(/^\/+/, "");
-        const target = `/to/${this.store.endpointId}${path ? "/" + path : ""}`;
+        const target = this._sendTarget();
         try {
           this.sendFailed = false;
           this.sendStatus = "Sending…";
@@ -376,18 +394,19 @@
             headers: parsed.headers,
             body: this.sendForm.body || undefined,
           });
-          this.sendFailed = !res.ok;
-          this.sendStatus = res.ok
-            ? `Sent ${this.sendForm.method}`
-            : `The server rejected it: HTTP ${res.status}.`;
-          this.announce(this.sendStatus);
-          if (res.ok) setTimeout(() => (this.sendStatus = ""), 2000);
+          if (!res.ok) {
+            this._reportSend(
+              true,
+              `The server rejected it: HTTP ${res.status}.`,
+            );
+            return;
+          }
+          this._reportSend(false, `Sent ${this.sendForm.method}`);
+          setTimeout(() => (this.sendStatus = ""), 2000);
         } catch (err) {
           // The browser refuses some combinations outright, e.g. a body on GET.
           // Report its reason rather than swallowing it, and keep it on screen.
-          this.sendFailed = true;
-          this.sendStatus = `Could not send: ${err.message}`;
-          this.announce(this.sendStatus);
+          this._reportSend(true, `Could not send: ${err.message}`);
         }
       },
     };

--- a/public/har.js
+++ b/public/har.js
@@ -71,11 +71,7 @@
         headers: entryHeaders(request.headers),
         queryString: entryQueryString(request.queryString),
         ...(postData ? { postData } : {}),
-        // Byte length of the captured body, which httphq stores as a Go
-        // string, and encoding/json replaces invalid UTF-8 with U+FFFD on
-        // marshal, so for genuinely binary uploads this can differ from the
-        // true original size. See database.Request.Body.
-        bodySize: new TextEncoder().encode(body).length,
+        bodySize: window.byteLength(body),
       },
     };
   }

--- a/public/index.js
+++ b/public/index.js
@@ -70,7 +70,16 @@ window.pluralize = function (count, noun) {
   return `${count} ${count === 1 ? noun : `${noun}s`}`;
 };
 
-/* Byte sizes for captured bodies. */
+/* Byte sizes for captured bodies.
+
+   Measured in bytes rather than characters, and measured on what was stored:
+   httphq holds a body as a Go string, and encoding/json replaces invalid UTF-8
+   with U+FFFD on the way out, so for a genuinely binary upload this can differ
+   from the original file's size. See database.Request.Body. */
+
+window.byteLength = function (text) {
+  return new TextEncoder().encode(text).length;
+};
 
 window.formatBytes = function (bytes) {
   if (bytes < 1024) return `${bytes} B`;

--- a/public/render-body.js
+++ b/public/render-body.js
@@ -45,6 +45,28 @@ function headerValue(headers, name) {
   return Array.isArray(value) ? value[0] : value;
 }
 
+/* Strips one layer of surrounding double quotes from a header parameter value.
+   A value carrying only one quote keeps it: that quote is content, not a
+   delimiter. */
+function unquote(value) {
+  const quoted =
+    value.length >= 2 && value.startsWith('"') && value.endsWith('"');
+  return quoted ? value.slice(1, -1) : value;
+}
+
+/* Looks up one parameter in a header's `key=value` parameter list, unquoted
+   and matched case-insensitively against a lower-case name. Returns null when
+   the list carries no such parameter, or carries it empty. */
+function headerParam(params, name) {
+  for (const param of params) {
+    const eq = param.indexOf("=");
+    if (eq > 0 && param.slice(0, eq).trim().toLowerCase() === name) {
+      return unquote(param.slice(eq + 1).trim()) || null;
+    }
+  }
+  return null;
+}
+
 /* Extracts the `boundary` parameter from a multipart/form-data Content-Type
    header value (quoted or unquoted). Returns null if the header isn't
    multipart/form-data or carries no boundary. */
@@ -52,24 +74,61 @@ function multipartBoundary(contentType) {
   if (!contentType) return null;
   const [mime, ...params] = contentType.split(";").map((s) => s.trim());
   if (mime.toLowerCase() !== "multipart/form-data") return null;
-  for (const param of params) {
-    const eq = param.indexOf("=");
-    if (eq <= 0) continue;
-    if (param.slice(0, eq).trim().toLowerCase() !== "boundary") continue;
-    let value = param.slice(eq + 1).trim();
-    if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
-      value = value.slice(1, -1);
-    }
-    return value || null;
-  }
-  return null;
+  return headerParam(params, "boundary");
 }
 
-/* Best-effort parse of a raw multipart/form-data body into an ordered array
-   of parts: {name, value} for fields, {name, filename, contentType, size}
-   for file parts (the file content itself is never shown). Returns null on
-   anything that doesn't look like well-formed multipart, so the caller can
-   fall through to the next rendering strategy. */
+/* Drops the line break that ended the delimiter above a part and the one that
+   opens the delimiter below it. Both belong to the framing rather than to the
+   part. A bare LF is accepted alongside CRLF because a hand-rolled sender does
+   not reliably send CRLF. */
+function trimPartFraming(segment) {
+  return segment.replace(/^\r?\n/, "").replace(/\r?\n$/, "");
+}
+
+/* Splits a part at the blank line separating its headers from its content.
+   Returns null when there is no blank line, which means the segment is not a
+   well-formed part. */
+function splitPart(segment) {
+  const headerEnd = segment.search(/\r?\n\r?\n/);
+  if (headerEnd === -1) return null;
+  const contentMatch = segment.slice(headerEnd).match(/^\r?\n\r?\n([\s\S]*)$/);
+  return {
+    headerLines: segment.slice(0, headerEnd).split(/\r?\n/),
+    content: contentMatch ? contentMatch[1] : "",
+  };
+}
+
+/* Turns one part's headers and content into {name, value} for a field or
+   {name, filename, contentType, size} for a file. Returns null when the part
+   carries no field name, which is a part the panel cannot label. */
+function partFromHeaders(headerLines, content) {
+  const disposition = headerLines.find((line) =>
+    /^content-disposition\s*:/i.test(line),
+  );
+  const nameMatch = disposition && disposition.match(/name="([^"]*)"/i);
+  if (!nameMatch) return null;
+  const name = nameMatch[1];
+
+  const filenameMatch = disposition.match(/filename="([^"]*)"/i);
+  if (!filenameMatch) return { name, value: content };
+
+  const contentTypeLine = headerLines.find((line) =>
+    /^content-type\s*:/i.test(line),
+  );
+  return {
+    name,
+    filename: filenameMatch[1],
+    contentType: contentTypeLine
+      ? contentTypeLine.split(":").slice(1).join(":").trim()
+      : "application/octet-stream",
+    // The part is described, never shown: a file's own bytes stay off screen.
+    size: window.byteLength(content),
+  };
+}
+
+/* Best-effort parse of a raw multipart/form-data body into an ordered array of
+   parts. Returns null on anything that doesn't look like well-formed
+   multipart, so the caller can fall through to the next rendering strategy. */
 function parseMultipart(body, boundary) {
   const segments = body.split("--" + boundary);
   // segments[0] is the preamble before the first delimiter, and the last
@@ -78,76 +137,47 @@ function parseMultipart(body, boundary) {
   if (segments.length < 3) return null;
 
   const parts = [];
-  for (let i = 1; i < segments.length - 1; i++) {
-    let segment = segments[i];
-    if (segment.startsWith("\r\n")) segment = segment.slice(2);
-    else if (segment.startsWith("\n")) segment = segment.slice(1);
-    if (segment.endsWith("\r\n")) segment = segment.slice(0, -2);
-    else if (segment.endsWith("\n")) segment = segment.slice(0, -1);
-
-    const headerEnd = segment.search(/\r?\n\r?\n/);
-    if (headerEnd === -1) return null;
-    const headerLines = segment.slice(0, headerEnd).split(/\r?\n/);
-    const contentMatch = segment
-      .slice(headerEnd)
-      .match(/^\r?\n\r?\n([\s\S]*)$/);
-    const content = contentMatch ? contentMatch[1] : "";
-
-    const disposition = headerLines.find((line) =>
-      /^content-disposition\s*:/i.test(line),
-    );
-    if (!disposition) return null;
-
-    const nameMatch = disposition.match(/name="([^"]*)"/i);
-    if (!nameMatch) return null;
-    const name = nameMatch[1];
-
-    const filenameMatch = disposition.match(/filename="([^"]*)"/i);
-    if (!filenameMatch) {
-      parts.push({ name, value: content });
-      continue;
-    }
-
-    const contentTypeLine = headerLines.find((line) =>
-      /^content-type\s*:/i.test(line),
-    );
-    const contentType = contentTypeLine
-      ? contentTypeLine.split(":").slice(1).join(":").trim()
-      : "application/octet-stream";
-    parts.push({
-      name,
-      filename: filenameMatch[1],
-      contentType,
-      // Byte length of the captured body, which httphq stores as a Go
-      // string, and encoding/json replaces invalid UTF-8 with U+FFFD on
-      // marshal, so for genuinely binary uploads this can differ from the
-      // true original file size. See database.Request.Body.
-      size: new TextEncoder().encode(content).length,
-    });
+  for (const segment of segments.slice(1, -1)) {
+    const split = splitPart(trimPartFraming(segment));
+    if (split === null) return null;
+    const part = partFromHeaders(split.headerLines, split.content);
+    if (part === null) return null;
+    parts.push(part);
   }
   return parts;
 }
 
-window.renderBody = function (body, headers) {
-  if (body == null || body === "") return "";
-
+function renderMultipart(body, headers) {
   const boundary = multipartBoundary(headerValue(headers, "Content-Type"));
-  if (boundary) {
-    const parts = parseMultipart(body, boundary);
-    if (parts !== null) return highlightPrettyJSON(parts);
-    // Malformed multipart body: fall through to the generic paths below.
-  }
+  if (!boundary) return null;
+  const parts = parseMultipart(body, boundary);
+  return parts === null ? null : highlightPrettyJSON(parts);
+}
 
-  // Each strategy claims less about the payload than the one before it, and
-  // falls through rather than reporting a failure: a body that answers to none
-  // of them is still a body the reader needs in front of them.
+function renderJSON(body) {
   try {
     return highlightPrettyJSON(JSON.parse(body));
   } catch {
-    // not JSON
+    return null;
   }
-  if (body.trimStart().startsWith("<")) {
-    return highlight(body, "xml");
+}
+
+function renderXML(body) {
+  return body.trimStart().startsWith("<") ? highlight(body, "xml") : null;
+}
+
+/* Ordered fallback. Each strategy claims less about the payload than the one
+   before it and returns null to hand the body to the next rather than
+   reporting a failure: a body that answers to none of them is still a body the
+   reader needs in front of them, so the last word is escaped raw text. */
+const renderStrategies = [renderMultipart, renderJSON, renderXML];
+
+window.renderBody = function (body, headers) {
+  if (body == null || body === "") return "";
+
+  for (const strategy of renderStrategies) {
+    const rendered = strategy(body, headers);
+    if (rendered !== null) return rendered;
   }
   return htmlEscape(body);
 };

--- a/src/assets_test.go
+++ b/src/assets_test.go
@@ -42,6 +42,37 @@ func templateFiles(t *testing.T) []string {
 	return files
 }
 
+// eachTemplate reads every template and hands its path and source to fn, so a
+// check over the template set says what it asserts rather than how it reads
+// the files.
+func eachTemplate(t *testing.T, fn func(path, source string)) {
+	t.Helper()
+	for _, path := range templateFiles(t) {
+		body, err := os.ReadFile(path)
+		require.NoError(t, err)
+		fn(path, string(body))
+	}
+}
+
+// helperVersioned collects the asset paths one template wraps in the asset
+// helper.
+func helperVersioned(source string) map[string]bool {
+	versioned := map[string]bool{}
+	for _, m := range assetHelperCall.FindAllStringSubmatch(source, -1) {
+		versioned[m[1]] = true
+	}
+	return versioned
+}
+
+// knownAssets collects the paths the startup hash pass walks.
+func knownAssets() map[string]bool {
+	known := map[string]bool{}
+	for _, path := range versionedAssets {
+		known[path] = true
+	}
+	return known
+}
+
 // assetDir populates a throwaway directory with every versioned asset, so an
 // index built on it behaves as it does against public/ without depending on
 // what happens to be committed there.
@@ -73,40 +104,27 @@ func rewriteAsset(t *testing.T, dir, path, contents string) {
 // damage only appears at a CDN edge after a deploy.
 func TestAssetReferences(t *testing.T) {
 	t.Run("every local asset reference goes through the helper", func(t *testing.T) {
-		for _, path := range templateFiles(t) {
-			body, err := os.ReadFile(path)
-			require.NoError(t, err)
-			source := string(body)
-
-			versioned := map[string]bool{}
-			for _, m := range assetHelperCall.FindAllStringSubmatch(source, -1) {
-				versioned[m[1]] = true
-			}
-
+		eachTemplate(t, func(path, source string) {
+			versioned := helperVersioned(source)
 			for _, m := range localAssetRef.FindAllStringSubmatch(source, -1) {
 				assert.Truef(t, versioned[m[1]],
 					"%s references %s without the asset helper; wrap it as {{asset `%s`}} so a cache cannot serve a stale copy against new markup",
 					path, m[1], m[1])
 			}
-		}
+		})
 	})
 
 	// Every asset the templates ask the helper to version has to be in the list
 	// the startup hash pass walks, or it ships unversioned in production.
 	t.Run("templates only version assets the index knows about", func(t *testing.T) {
-		known := map[string]bool{}
-		for _, path := range versionedAssets {
-			known[path] = true
-		}
-		for _, path := range templateFiles(t) {
-			body, err := os.ReadFile(path)
-			require.NoError(t, err)
-			for _, m := range assetHelperCall.FindAllStringSubmatch(string(body), -1) {
+		known := knownAssets()
+		eachTemplate(t, func(path, source string) {
+			for _, m := range assetHelperCall.FindAllStringSubmatch(source, -1) {
 				assert.Truef(t, known[m[1]],
 					"%s versions %s but it is missing from versionedAssets, so no hash is computed for it at startup",
 					path, m[1])
 			}
-		}
+		})
 	})
 
 	// The helper falls back to an unversioned path when it cannot read a file,
@@ -150,6 +168,18 @@ func TestAssetIndex(t *testing.T) {
 	// caching risk, a broken reference is a broken page.
 	t.Run("an unreadable asset falls back to its plain path", func(t *testing.T) {
 		index := newAssetIndex(filepath.Join(t.TempDir(), "does-not-exist"), false)
+
+		assert.Equal(t, "/app.css", index.url("/app.css"))
+	})
+
+	// A path that names a directory opens cleanly and only then fails to read,
+	// which is a different branch from a path that is not there at all. Both
+	// have to fall back, or a deploy that shadows an asset serves a bare page.
+	t.Run("a path shadowed by a directory falls back to its plain path", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "app.css"), 0o750))
+
+		index := newAssetIndex(dir, false)
 
 		assert.Equal(t, "/app.css", index.url("/app.css"))
 	})

--- a/src/capture.go
+++ b/src/capture.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
+	"maps"
 	"net/http"
 
 	"github.com/gofiber/contrib/v3/socketio"
@@ -48,17 +50,22 @@ var spoofedCurlHeaders = map[string][]string{
 	"User-Agent":   {"curl/7.79.1"},
 }
 
+// curlSpoofRequested reports whether the sender asked for its request to be
+// captured as a command-line client's rather than the browser's.
+func curlSpoofRequested(headers map[string][]string) bool {
+	spoof := headers[spoofCurlHeader]
+	return len(spoof) > 0 && spoof[0] == "true"
+}
+
 // captureHeaders reduces the request's headers to what the user should see: the
 // browser's own additions removed when curl is spoofed, then every
 // infrastructure header stripped.
 func captureHeaders(headers map[string][]string) map[string][]string {
-	if spoof, ok := headers[spoofCurlHeader]; ok && len(spoof) > 0 && spoof[0] == "true" {
+	if curlSpoofRequested(headers) {
 		for _, name := range browserOnlyHeaders {
 			delete(headers, name)
 		}
-		for name, value := range spoofedCurlHeaders {
-			headers[name] = value
-		}
+		maps.Copy(headers, spoofedCurlHeaders)
 	}
 	for name := range headers {
 		if omitHeader(name) {
@@ -81,6 +88,26 @@ func flattenHeaders(headers map[string][]string) map[string]any {
 		}
 	}
 	return flat
+}
+
+// emitToSockets dispatches a payload to a list of live sockets. It is a
+// variable so a test can assert what fan-out sends without opening one.
+var emitToSockets = socketio.EmitToList
+
+// broadcastCapture pushes a stored capture to every socket watching its
+// endpoint. It marshals once and dispatches asynchronously so a slow client
+// does not stall the capture handler.
+func broadcastCapture(ctx context.Context, registry *socketRegistry, request database.Request) {
+	uuids := registry.uuidsFor(request.EndpointID)
+	if len(uuids) == 0 {
+		return
+	}
+	marshalled, err := json.Marshal(request)
+	if err != nil {
+		slog.ErrorContext(ctx, "websocket payload marshal failed", "err", err)
+		return
+	}
+	go emitToSockets(uuids, marshalled)
 }
 
 // captureRequest stores an inbound request against its endpoint and pushes it to
@@ -118,16 +145,7 @@ func captureRequest(registry *socketRegistry) fiber.Handler {
 		}
 		database.CreateRequest(c.Context(), &request)
 
-		// Fan-out to subscribed WS clients. Marshal once, then dispatch
-		// asynchronously so a slow client doesn't stall the capture handler.
-		if uuids := registry.uuidsFor(endpointID); len(uuids) > 0 {
-			marshalled, marshalErr := json.Marshal(request)
-			if marshalErr != nil {
-				slog.ErrorContext(c.Context(), "websocket payload marshal failed", "err", marshalErr)
-			} else {
-				go socketio.EmitToList(uuids, marshalled)
-			}
-		}
+		broadcastCapture(c.Context(), registry, request)
 
 		c.Set(captureUUIDHeader, request.UUID)
 		return c.SendStatus(http.StatusOK)

--- a/src/capture_test.go
+++ b/src/capture_test.go
@@ -6,9 +6,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"httphq/src/database"
 )
 
 func TestCaptureRequest(t *testing.T) {
@@ -243,5 +246,85 @@ func TestFlattenHeaders(t *testing.T) {
 
 	t.Run("no headers flatten to an empty object", func(t *testing.T) {
 		assert.Empty(t, flattenHeaders(map[string][]string{}))
+	})
+}
+
+// socketEmit is one fan-out dispatch: the sockets addressed and the payload
+// they were sent.
+type socketEmit struct {
+	uuids   []string
+	message []byte
+}
+
+// recordSocketEmits swaps the socket emitter for one that records what fan-out
+// dispatches. The emitter is process-wide, so a test that swaps it has to put
+// it back.
+func recordSocketEmits(t *testing.T) chan socketEmit {
+	t.Helper()
+	emits := make(chan socketEmit, 4)
+	previous := emitToSockets
+	emitToSockets = func(uuids []string, message []byte, _ ...int) {
+		emits <- socketEmit{uuids: uuids, message: message}
+	}
+	t.Cleanup(func() { emitToSockets = previous })
+	return emits
+}
+
+// awaitEmit returns the next dispatch. Fan-out runs in its own goroutine so
+// that a slow client cannot stall a capture, which means a test has to wait for
+// it rather than read the channel outright.
+func awaitEmit(t *testing.T, emits chan socketEmit) socketEmit {
+	t.Helper()
+	select {
+	case emit := <-emits:
+		return emit
+	case <-time.After(2 * time.Second):
+		t.Fatal("fan-out dispatched nothing")
+		return socketEmit{}
+	}
+}
+
+// Fan-out is what makes the feed live, so what matters is that a capture
+// reaches every socket watching its own endpoint and no others. The emitter is
+// swapped rather than a socket opened: the payload a watching page receives is
+// the subject here, not the transport under it.
+func TestBroadcastCapture(t *testing.T) {
+	captured := database.Request{
+		UUID:       "capture-uuid",
+		EndpointID: "watched",
+		Method:     http.MethodPost,
+		Body:       `{"hello":"world"}`,
+	}
+
+	t.Run("every socket watching the endpoint receives the capture", func(t *testing.T) {
+		emits := recordSocketEmits(t)
+		registry := newSocketRegistry()
+		registry.add("watched", "socket-1")
+		registry.add("watched", "socket-2")
+
+		broadcastCapture(t.Context(), registry, captured)
+
+		emit := awaitEmit(t, emits)
+		assert.ElementsMatch(t, []string{"socket-1", "socket-2"}, emit.uuids)
+
+		var payload database.Request
+		require.NoError(t, json.Unmarshal(emit.message, &payload),
+			"a page parses the pushed payload as a capture")
+		assert.Equal(t, captured.UUID, payload.UUID)
+		assert.Equal(t, captured.Body, payload.Body)
+	})
+
+	// The endpoint ID is the only isolation between two users of one instance,
+	// so a page open on another endpoint must never be pushed this traffic.
+	t.Run("a socket watching another endpoint is left alone", func(t *testing.T) {
+		emits := recordSocketEmits(t)
+		registry := newSocketRegistry()
+		registry.add("other", "socket-1")
+
+		broadcastCapture(t.Context(), registry, captured)
+
+		// Nothing is dispatched asynchronously either: with no socket on the
+		// endpoint, fan-out returns before it marshals or starts a goroutine.
+		assert.Empty(t, emits)
 	})
 }

--- a/src/database/database_test.go
+++ b/src/database/database_test.go
@@ -1,8 +1,10 @@
 package database_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -18,6 +20,19 @@ import (
 func freshDB(t *testing.T) {
 	t.Helper()
 	database.Connect(":memory:")
+}
+
+// captureLogs points the process logger at a buffer for one test. Every
+// operation here answers with a zero value, so a failure it ran into is
+// reported through the logs or nowhere, and this is the only way to read it.
+// The logger is process-wide, so it is restored before the next test.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var out bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&out, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	return &out
 }
 
 // requestOption customises a fixture request. Only the fields a test asserts on
@@ -70,6 +85,34 @@ func TestConnect(t *testing.T) {
 		var tables []string
 		database.DB.Raw(`SELECT name FROM sqlite_schema WHERE type = 'table' ORDER BY name`).Scan(&tables)
 		assert.Equal(t, []string{"requests"}, tables)
+	})
+}
+
+// Every operation answers with a zero value rather than an error, because the
+// caller is a request handler that still has to respond. That makes a broken
+// store indistinguishable from an empty one at every call site, so the log line
+// is the only report there is and it has to be there.
+func TestBrokenStore(t *testing.T) {
+	t.Run("a failed query answers empty and reports itself to the logs", func(t *testing.T) {
+		freshDB(t)
+		logs := captureLogs(t)
+		require.NoError(t, database.DB.Migrator().DropTable(&database.Request{}))
+
+		assert.Equal(t, int64(0), database.CountRequests(t.Context()))
+		assert.Contains(t, logs.String(), "count requests failed")
+	})
+
+	t.Run("a failed listing answers with no requests at all", func(t *testing.T) {
+		freshDB(t)
+		logs := captureLogs(t)
+		require.NoError(t, database.DB.Migrator().DropTable(&database.Request{}))
+
+		listed := database.GetRequestsForEndpointID(t.Context(), "any-endpoint", "", time.Time{}, 10)
+
+		assert.Empty(t, listed, "a caller must not be handed a half-read page")
+		assert.Contains(t, logs.String(), "get requests failed")
+		assert.Contains(t, logs.String(), "any-endpoint",
+			"the log names the endpoint, or an operator cannot tell which one broke")
 	})
 }
 

--- a/src/harness_test.go
+++ b/src/harness_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
 
 	"httphq/src/database"
 )
@@ -75,6 +77,25 @@ func withPlatform(t *testing.T, name string) {
 	previous := currentPlatform
 	currentPlatform = resolvePlatform(name)
 	t.Cleanup(func() { currentPlatform = previous })
+}
+
+// contextWith builds a request context from peerIP carrying the given headers,
+// so a test can exercise the header-reading helpers without a live server.
+func contextWith(t *testing.T, app *fiber.App, peerIP string, headers map[string]string) fiber.Ctx {
+	t.Helper()
+
+	fctx := &fasthttp.RequestCtx{}
+	if peerIP != "" {
+		fctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP(peerIP)})
+	}
+
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	for name, value := range headers {
+		c.Request().Header.Set(name, value)
+	}
+	return c
 }
 
 type testRequest struct {

--- a/src/logging/logging.go
+++ b/src/logging/logging.go
@@ -78,22 +78,21 @@ func replaceAttr(groups []string, a slog.Attr) slog.Attr {
 // a deployment is not paying to record its own debug chatter, and debug
 // everywhere else. An operator overrides either with LOG_LEVEL; an unrecognised
 // value leaves the environment's default in place.
+var logLevels = map[string]slog.Level{
+	"debug": slog.LevelDebug,
+	"info":  slog.LevelInfo,
+	"warn":  slog.LevelWarn,
+	"error": slog.LevelError,
+}
+
 func resolveLevel(env, override string) slog.Level {
-	level := slog.LevelDebug
+	if level, ok := logLevels[strings.ToLower(override)]; ok {
+		return level
+	}
 	if env == "production" {
-		level = slog.LevelInfo
-	}
-	switch strings.ToLower(override) {
-	case "debug":
-		return slog.LevelDebug
-	case "info":
 		return slog.LevelInfo
-	case "warn":
-		return slog.LevelWarn
-	case "error":
-		return slog.LevelError
 	}
-	return level
+	return slog.LevelDebug
 }
 
 // Init installs the process-wide slog logger: JSON to stdout, an OTel-named

--- a/src/platform.go
+++ b/src/platform.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
@@ -89,16 +90,8 @@ func trustedProxyConfig() fiber.TrustProxyConfig {
 // header is a list) and validates it parses. With no platform configured, or
 // when the header is missing or malformed, it falls back to the TCP peer.
 func resolveClientIP(c fiber.Ctx) string {
-	if currentPlatform.ipHeader != "" {
-		v := c.Get(currentPlatform.ipHeader)
-		if currentPlatform.ipList {
-			if i := strings.IndexByte(v, ','); i >= 0 {
-				v = v[:i]
-			}
-		}
-		if ip := net.ParseIP(strings.TrimSpace(v)); ip != nil {
-			return ip.String()
-		}
+	if ip := net.ParseIP(platformClientIP(c)); ip != nil {
+		return ip.String()
 	}
 	if ip := net.ParseIP(c.IP()); ip != nil {
 		return ip.String()
@@ -106,19 +99,30 @@ func resolveClientIP(c fiber.Ctx) string {
 	return ""
 }
 
+// platformClientIP returns the raw client IP the configured PLATFORM's header
+// carries, taking the leftmost entry when that header is a list. Empty when no
+// platform is configured, which leaves the caller on the TCP peer.
+func platformClientIP(c fiber.Ctx) string {
+	if currentPlatform.ipHeader == "" {
+		return ""
+	}
+	v := c.Get(currentPlatform.ipHeader)
+	if currentPlatform.ipList {
+		if i := strings.IndexByte(v, ','); i >= 0 {
+			v = v[:i]
+		}
+	}
+	return strings.TrimSpace(v)
+}
+
 // omitHeader reports whether a captured-request header is infrastructure
 // noise, meaning a generic forwarding header or a vendor header added by the
 // configured PLATFORM, and so should be hidden from the user.
 func omitHeader(name string) bool {
-	for _, h := range omittedHeaders {
-		if strings.EqualFold(name, h) {
-			return true
-		}
+	sameName := func(h string) bool { return strings.EqualFold(name, h) }
+	hasPrefix := func(prefix string) bool {
+		return len(name) >= len(prefix) && strings.EqualFold(name[:len(prefix)], prefix)
 	}
-	for _, prefix := range currentPlatform.stripPrefix {
-		if len(name) >= len(prefix) && strings.EqualFold(name[:len(prefix)], prefix) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(omittedHeaders[:], sameName) ||
+		slices.ContainsFunc(currentPlatform.stripPrefix, hasPrefix)
 }

--- a/src/platform_test.go
+++ b/src/platform_test.go
@@ -1,32 +1,11 @@
 package main
 
 import (
-	"net"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/assert"
-	"github.com/valyala/fasthttp"
 )
-
-// contextWith builds a request context from peerIP carrying the given headers,
-// so a test can exercise the header-reading helpers without a live server.
-func contextWith(t *testing.T, app *fiber.App, peerIP string, headers map[string]string) fiber.Ctx {
-	t.Helper()
-
-	fctx := &fasthttp.RequestCtx{}
-	if peerIP != "" {
-		fctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP(peerIP)})
-	}
-
-	c := app.AcquireCtx(fctx)
-	t.Cleanup(func() { app.ReleaseCtx(c) })
-
-	for name, value := range headers {
-		c.Request().Header.Set(name, value)
-	}
-	return c
-}
 
 // schemeFor returns the scheme Fiber resolves for a request from peerIP
 // carrying the given X-Forwarded-Proto (empty = header absent). The connection
@@ -141,6 +120,17 @@ func TestResolveClientIP(t *testing.T) {
 		})
 
 		assert.Equal(t, "2001:db8::1", resolveClientIP(c))
+	})
+
+	// A connection with no readable peer reports 0.0.0.0 rather than nothing,
+	// so that is what a capture stores and a reader sees. It looks like an
+	// address the client owned, and nothing downstream corrects that.
+	t.Run("an unreadable peer is reported as 0.0.0.0", func(t *testing.T) {
+		withPlatform(t, "cloudflare")
+
+		c := contextWith(t, app, "", map[string]string{"Cf-Connecting-Ip": "not-an-ip"})
+
+		assert.Equal(t, "0.0.0.0", resolveClientIP(c))
 	})
 }
 

--- a/src/requestlog_test.go
+++ b/src/requestlog_test.go
@@ -3,11 +3,13 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -136,6 +138,17 @@ func TestResponseStatus(t *testing.T) {
 		record := accessLogFor(t, testRequest{method: http.MethodGet, path: "/no/such/page"})
 
 		assert.Equal(t, float64(http.StatusNotFound), record["http.response.status_code"])
+	})
+
+	// An error that names no status is still answered, and Fiber answers it
+	// with 500. Reading the response instead would log the untouched default
+	// and record the failure as a success.
+	t.Run("a failure that names no status is logged as a server error", func(t *testing.T) {
+		c := contextWith(t, fiber.New(), "203.0.113.7", nil)
+
+		status := responseStatus(c, errors.New("handler gave up"))
+
+		assert.Equal(t, http.StatusInternalServerError, status)
 	})
 }
 


### PR DESCRIPTION
The ten highest-complexity functions had accumulated avoidable branching, and a cyclomatic audit put the multipart parser at 13 and the capture header path at 8. This PR splits those functions, shares three helpers that were duplicated across page scripts, and adds the tests that were missing underneath them. Byte length, the method palette fallback and the body locator each now live in one place.

Nothing changes at runtime. Every refactor is behaviour-preserving and was checked against a differential harness over 32 body shapes. Two new specs drive the browser scripts directly, because the server re-serialises a multipart body before storing it and several part shapes never reach the page intact. The pre-existing hydration wait in endpoint-screen.spec.ts stays flaky locally, at roughly 2 to 7 failures per run, because it waits on Alpine from a CDN. CI retries twice. This PR does not touch that wait, the capture path or any user-facing copy.

1. Run `go test ./src/... -cover`.
2. Run `npm run lint`.
3. Build the binary with `CGO_ENABLED=0 go build -o ./bin/httphq ./src`.
4. Run `npx playwright test tests/render-body.spec.ts tests/page-helpers.spec.ts` from `e2e`.
5. Open an endpoint page and post a multipart form to it.
6. Confirm the body panel lists the parts and hides file contents.