### PR TITLE
Enforce a cyclomatic complexity ceiling on both sides

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,10 @@ jobs:
       # Scoped to src: node_modules ships a stray Go package that ./... would
       # otherwise build.
       - run: go vet ./src/...
+      # The Go counterpart to the `complexity` rule the page scripts are linted
+      # with. Pinned so a later gocyclo release cannot change the verdict on a
+      # tree that did not change.
+      - run: go run github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0 -over 5 ./src
       - run: go test ./src/...
   lint:
     runs-on: ubuntu-latest

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -52,6 +52,19 @@ go test ./src/...
 Every Go package lives under `src`. `./...` also walks `node_modules`, which
 ships a stray Go package once the npm tooling is installed.
 
+Check cyclomatic complexity:
+
+```bash
+go run github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0 -over 5 ./src
+go run github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0 -top 10 ./src
+```
+
+Both sides carry a ceiling, and both are set at the worst score the tree
+currently holds: `-over 5` for Go, and the `complexity` rule in
+`eslint.config.mjs` at 6 for the page scripts and the Playwright suite. `-top`
+takes no position and is the one to run when deciding what to simplify next.
+Neither ceiling grandfathers anything, so lower them as hotspots go.
+
 Run E2E tests (Playwright auto-starts the binary; build it first):
 
 ```bash

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,13 @@ export default tseslint.config(
     ],
   },
 
+  // Cyclomatic complexity ceiling, over every file linted here. It sits at the
+  // worst score the tree currently carries, so it holds the line rather than
+  // leaving room to grow into, and a function that gains a branch has to lose
+  // one somewhere. ESLint's own default is 20, which everything here clears by
+  // a wide margin. Ratchet it down as hotspots are simplified.
+  { rules: { complexity: ["error", { max: 6 }] } },
+
   // Page scripts. No bundler and no module system: each file is a classic
   // script that publishes what the next one needs on `window`, so the globals
   // it defines and the ones it reads are both declared here.


### PR DESCRIPTION
The audit that cut the ten worst functions left the page scripts at 6 and Go at 5, but nothing holds those numbers. Any branch can climb back to 13 without a single reviewer noticing. This PR gates both sides at the score the tree carries today, so a function that gains a branch has to lose one somewhere.

Neither ceiling grandfathers an exception and neither leaves slack, which is deliberate and also means the first honest branch that needs a seventh path will bounce. Raising a number is a one-line change and a reason in the commit message. The Go check runs in the job that already runs `go vet`, and adds a module download to CI. ESLint's own default for this rule is 20, so this is far tighter than stock. No production code changes.

1. Run `npm run lint` and confirm it passes.
2. Run `go run github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0 -over 5 ./src`.
3. Confirm it prints nothing and exits 0.
4. Add a function with seven branches to any file under `public/`.
5. Run `npm run lint` again and confirm it now fails.