### PR TITLE
fix: measure bodies in bytes, revive the dead socket URL, and even up the suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,15 +30,19 @@ configuration out of the environment belongs in `main`, not in a handler.
 
 `e2e/tests` holds one spec per subject. A `*-screen.spec.ts` drives a screen
 through captured traffic and asserts what a reader ends up seeing.
-`render-body.spec.ts` and `page-helpers.spec.ts` drive the browser scripts
-directly through `loadPageScripts`, because traffic cannot express everything
-those scripts handle: the server parses and re-serialises a multipart body
-before storing it, so several part shapes a client can put on the wire never
-reach the page intact.
+`render-body.spec.ts`, `page-helpers.spec.ts` and `har-export.spec.ts` drive the
+browser scripts directly through `loadPageScripts`, because traffic cannot
+express everything those scripts handle: the server parses and re-serialises a
+multipart body before storing it, so several part shapes a client can put on the
+wire never reach the page intact, and neither a repeated header nor a body that
+is not ASCII survives the round trip through the test client.
+`capture-api.spec.ts` covers what only a client on the wire can observe, such as
+the body limit the server enforces around the handler rather than inside it.
 
-Fixtures used by more than one spec live in `tests/support/harness.ts`, which is
-also the one place a type is asserted rather than proven, at the `JSON.parse`
-and `response.json()` boundaries.
+A spec's own fixtures sit at the top of that spec, as the locator and multipart
+helpers do. Fixtures used by more than one spec live in
+`tests/support/harness.ts`, which is also the one place a type is asserted
+rather than proven, at the `JSON.parse` and `response.json()` boundaries.
 
 ## Comments
 

--- a/e2e/tests/endpoint-screen.spec.ts
+++ b/e2e/tests/endpoint-screen.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type APIResponse, type Page } from "@playwright/test";
 import {
   captureUrl,
   newEndpointId,
@@ -18,6 +18,28 @@ import {
  * server under test.
  */
 const HYDRATION_TIMEOUT_MS = 15_000;
+
+/**
+ * The parts of the screen the assertions below reach for. Each selector is
+ * spelled once rather than at every call site, so a change to the markup lands
+ * in one place.
+ */
+const stream = (page: Page) => page.locator('[data-test="requests"]');
+const resultCount = (page: Page) =>
+  page.locator('[data-test="search-results"]');
+const searchBox = (page: Page) => page.locator('[data-test="search-input"]');
+const newestCard = (page: Page) =>
+  page.locator('[data-test="request"]').first();
+
+/**
+ * The capture a send produced, found by the UUID the server echoes back. Going
+ * through the UUID rather than through position is what lets a test assert
+ * about its own request while the stream carries others.
+ */
+const capturedUuid = (response: APIResponse) =>
+  response.headers()["httphq-request-uuid"];
+
+const cardFor = (page: Page, uuid: string) => page.locator(`#request-${uuid}`);
 
 test.describe("Endpoint screen", () => {
   let endpointId: string;
@@ -79,33 +101,27 @@ test.describe("Endpoint screen", () => {
   });
 
   test.describe("Capture stream", () => {
-    test("shows the empty state when no requests exist", async ({ page }) => {
-      await expect(page.locator('[data-test="requests"]')).toContainText(
-        "Waiting for requests",
-      );
+    test("an endpoint with no traffic says it is waiting", async ({ page }) => {
+      await expect(stream(page)).toContainText("Waiting for requests");
     });
 
-    test("does not show the empty state once requests arrive", async ({
+    test("the waiting state goes once a request arrives", async ({
       page,
       request,
     }) => {
       await send(request, endpointUrl, { data: "Hello, World!" });
-      await expect(page.locator('[data-test="requests"]')).not.toContainText(
-        "Waiting for requests",
-      );
+      await expect(stream(page)).not.toContainText("Waiting for requests");
     });
 
-    test("displays new requests in real-time over WebSocket", async ({
+    test("a request sent while the page is open appears without a reload", async ({
       page,
       request,
     }) => {
       await send(request, endpointUrl, { data: "Real-time-payload" });
-      await expect(page.locator('[data-test="requests"]')).toContainText(
-        "Real-time-payload",
-      );
+      await expect(stream(page)).toContainText("Real-time-payload");
     });
 
-    test("renders request details, headers and body", async ({
+    test("a capture shows its details, headers and body", async ({
       page,
       request,
     }) => {
@@ -113,7 +129,7 @@ test.describe("Endpoint screen", () => {
         data: "Hello, World!",
         headers: { "Content-Type": "text/plain" },
       });
-      const card = page.locator('[data-test="request"]').first();
+      const card = newestCard(page);
       const details = card.locator('[data-test="request-details"]');
       await expect(details).toContainText(/now|seconds? ago/);
       await expect(details).toContainText("127.0.0.1");
@@ -151,9 +167,7 @@ test.describe("Endpoint screen", () => {
       request,
     }) => {
       await send(request, endpointUrl, { method: "GET" });
-      await expect(
-        newestBody(page),
-      ).toContainText("None");
+      await expect(newestBody(page)).toContainText("None");
     });
 
     test("the header count matches the headers listed", async ({
@@ -182,13 +196,27 @@ test.describe("Endpoint screen", () => {
       await expect(body).toContainText("2.0 KB");
     });
 
+    // The panel measures what was stored, which is bytes, matching the size the
+    // HAR export reports and the one a multipart part carries. An ASCII payload
+    // cannot tell the two apart, so this one is deliberately not ASCII: 2048
+    // characters here are 4096 bytes.
+    test("the payload size counts bytes rather than characters", async ({
+      page,
+      request,
+    }) => {
+      await send(request, endpointUrl, { data: "é".repeat(2048) });
+      const body = newestBody(page);
+
+      await expect(body).toContainText("4.0 KB");
+    });
+
     test("delete-request removes a single card", async ({ page, request }) => {
       await send(request, endpointUrl, { data: "first" });
       const response = await send(request, endpointUrl, {
         data: { msg: "second" },
       });
-      const uuid = response.headers()["httphq-request-uuid"];
-      const card = page.locator(`#request-${uuid}`);
+      const uuid = capturedUuid(response);
+      const card = cardFor(page, uuid);
       await expect(card).toBeAttached();
       await card.locator('[data-test="delete-request"]').click();
       await expect(card).not.toBeAttached();
@@ -212,9 +240,7 @@ test.describe("Endpoint screen", () => {
 
       await page.locator('[data-test="delete-requests"]').click();
       await page.locator('[data-test="delete-confirm-button"]').click();
-      await expect(page.locator('[data-test="requests"]')).toContainText(
-        "Waiting for requests",
-      );
+      await expect(stream(page)).toContainText("Waiting for requests");
     });
 
     // Nothing tells the page that the server swept a capture out from under it,
@@ -227,8 +253,8 @@ test.describe("Endpoint screen", () => {
       request,
     }) => {
       const response = await send(request, endpointUrl, { data: "swept" });
-      const uuid = response.headers()["httphq-request-uuid"];
-      await expect(page.locator(`#request-${uuid}`)).toBeAttached();
+      const uuid = capturedUuid(response);
+      await expect(cardFor(page, uuid)).toBeAttached();
 
       // Deleted behind the page's back, which is what the retention sweep is
       // from the page's point of view.
@@ -236,9 +262,7 @@ test.describe("Endpoint screen", () => {
 
       await pruneExpiredCaptures(page);
 
-      await expect(page.locator('[data-test="requests"]')).toContainText(
-        "Waiting for requests",
-      );
+      await expect(stream(page)).toContainText("Waiting for requests");
     });
 
     // Rendering every capture at once is a five-figure node count and a visible
@@ -251,9 +275,7 @@ test.describe("Endpoint screen", () => {
       for (let i = 0; i < overOnePage; i++) {
         await send(request, endpointUrl, { data: `payload-${i}` });
       }
-      await expect(page.locator('[data-test="search-results"]')).toContainText(
-        `${overOnePage} results`,
-      );
+      await expect(resultCount(page)).toContainText(`${overOnePage} results`);
 
       await expect(page.locator('[data-test="request"]')).toHaveCount(25);
       const showMore = page.locator('[data-test="show-more"]');
@@ -268,7 +290,7 @@ test.describe("Endpoint screen", () => {
   });
 
   test.describe("Body rendering", () => {
-    test("pretty-prints JSON bodies via highlight.js", async ({
+    test("a JSON body is pretty-printed and syntax-highlighted", async ({
       page,
       request,
     }) => {
@@ -286,7 +308,7 @@ test.describe("Endpoint screen", () => {
       expect(tokenCount).toBeGreaterThan(0);
     });
 
-    test("highlights XML bodies", async ({ page, request }) => {
+    test("an XML body is syntax-highlighted", async ({ page, request }) => {
       await send(request, endpointUrl, {
         data: "<root><a>1</a></root>",
         headers: { "Content-Type": "application/xml" },
@@ -311,7 +333,7 @@ test.describe("Endpoint screen", () => {
       await expect(body.locator("img")).toHaveCount(0);
     });
 
-    test("renders multipart/form-data fields as a parsed JSON array", async ({
+    test("a multipart body shows its fields as a parsed list", async ({
       page,
       request,
     }) => {
@@ -328,7 +350,7 @@ test.describe("Endpoint screen", () => {
       expect(tokenCount).toBeGreaterThan(0);
     });
 
-    test("renders multipart file parts as metadata only, never file content", async ({
+    test("a multipart file part shows metadata, never its content", async ({
       page,
       request,
     }) => {
@@ -348,7 +370,7 @@ test.describe("Endpoint screen", () => {
       expect(text).not.toContain("fake-png-bytes");
     });
 
-    test("keeps repeated multipart field names as separate array entries", async ({
+    test("a repeated multipart field name keeps each of its entries", async ({
       page,
       request,
     }) => {
@@ -367,7 +389,7 @@ test.describe("Endpoint screen", () => {
     // parameters. Taking the quotes as part of the boundary, or reading only
     // the first parameter, leaves nothing in the body matching the delimiter
     // and the whole payload falls through to raw text.
-    test("parses a multipart body whose boundary is quoted", async ({
+    test("a quoted boundary is parsed like an unquoted one", async ({
       page,
       request,
     }) => {
@@ -389,9 +411,8 @@ test.describe("Endpoint screen", () => {
       expect(text).toContain('"name": "city"');
       expect(text).toContain('"value": "Ghent"');
     });
-  });
 
-    test("falls back to raw display when a multipart body has no boundary", async ({
+    test("a multipart body with no boundary falls back to raw text", async ({
       page,
       request,
     }) => {
@@ -402,16 +423,14 @@ test.describe("Endpoint screen", () => {
       const body = newestBody(page);
       await expect(body).toContainText("not-actually-parseable-multipart");
     });
+  });
 
   test.describe("Filtering", () => {
-    test("filters by request body via the search box", async ({
-      page,
-      request,
-    }) => {
+    test("the search box narrows by body", async ({ page, request }) => {
       await send(request, endpointUrl, { data: "Hello, World!" });
-      const requests = page.locator('[data-test="requests"]');
-      const results = page.locator('[data-test="search-results"]');
-      const search = page.locator('[data-test="search-input"]');
+      const requests = stream(page);
+      const results = resultCount(page);
+      const search = searchBox(page);
 
       await expect(requests).toContainText("Hello, World!");
 
@@ -427,7 +446,7 @@ test.describe("Endpoint screen", () => {
       await expect(requests).not.toContainText("Waiting for requests");
     });
 
-    test("filters by header key/value via the search box", async ({
+    test("the search box narrows by header name and value", async ({
       page,
       request,
     }) => {
@@ -437,9 +456,9 @@ test.describe("Endpoint screen", () => {
         data: "x",
         headers: { [key]: value },
       });
-      const requests = page.locator('[data-test="requests"]');
-      const results = page.locator('[data-test="search-results"]');
-      const search = page.locator('[data-test="search-input"]');
+      const requests = stream(page);
+      const results = resultCount(page);
+      const search = searchBox(page);
 
       await expect(requests).toContainText(key);
       await expect(requests).toContainText(value);
@@ -454,16 +473,16 @@ test.describe("Endpoint screen", () => {
       await expect(results).toContainText("0 results");
     });
 
-    test("filters by query string via the search box", async ({
+    test("the search box narrows by query string", async ({
       page,
       request,
     }) => {
       await send(request, `${endpointUrl}?event=charge.succeeded`, {
         data: "x",
       });
-      const results = page.locator('[data-test="search-results"]');
+      const results = resultCount(page);
 
-      await page.locator('[data-test="search-input"]').fill("charge.succeeded");
+      await searchBox(page).fill("charge.succeeded");
       await expect(results).toContainText("1 result");
     });
 
@@ -474,14 +493,10 @@ test.describe("Endpoint screen", () => {
       request,
     }) => {
       await send(request, endpointUrl, { data: "only" });
-      await expect(page.locator('[data-test="search-results"]')).toHaveText(
-        "1 result",
-      );
+      await expect(resultCount(page)).toHaveText("1 result");
 
       await send(request, endpointUrl, { data: "second" });
-      await expect(page.locator('[data-test="search-results"]')).toHaveText(
-        "2 results",
-      );
+      await expect(resultCount(page)).toHaveText("2 results");
     });
 
     test("the method filter narrows the list to matching methods", async ({
@@ -492,20 +507,14 @@ test.describe("Endpoint screen", () => {
       await send(request, endpointUrl, { method: "PUT", data: "p2" });
       await send(request, endpointUrl, { method: "DELETE" });
 
-      await expect(page.locator('[data-test="search-results"]')).toContainText(
-        "3 results",
-      );
+      await expect(resultCount(page)).toContainText("3 results");
 
       await page.locator('[data-test="method-filter"]').selectOption("POST");
-      await expect(page.locator('[data-test="search-results"]')).toContainText(
-        "1 result",
-      );
+      await expect(resultCount(page)).toContainText("1 result");
       await expect(page.locator('[data-test="request"]')).toHaveCount(1);
 
       await page.locator('[data-test="method-filter"]').selectOption("");
-      await expect(page.locator('[data-test="search-results"]')).toContainText(
-        "3 results",
-      );
+      await expect(resultCount(page)).toContainText("3 results");
     });
 
     test("a filtered-empty stream is not reported as waiting", async ({
@@ -555,10 +564,8 @@ test.describe("Endpoint screen", () => {
       await send(request, endpointUrl, { data: "beta" });
       await expect(page.locator('[data-test="request"]')).toHaveCount(2);
 
-      await page.locator('[data-test="search-input"]').fill("alpha");
-      await expect(page.locator('[data-test="search-results"]')).toContainText(
-        "1 result",
-      );
+      await searchBox(page).fill("alpha");
+      await expect(resultCount(page)).toContainText("1 result");
       await expect(
         page.locator('[data-test="delete-requests-label"]'),
       ).toContainText("Delete all (2)");
@@ -596,7 +603,7 @@ test.describe("Endpoint screen", () => {
         data: raw,
         headers: { "Content-Type": "application/json" },
       });
-      const card = page.locator('[data-test="request"]').first();
+      const card = newestCard(page);
       await card.locator('[data-test="copy-body"]').click();
       expect(await readClipboard(page)).toBe(raw);
     });
@@ -609,7 +616,7 @@ test.describe("Endpoint screen", () => {
         data: "x",
         headers: { "X-Sample": "value" },
       });
-      const card = page.locator('[data-test="request"]').first();
+      const card = newestCard(page);
       await card.locator('[data-test="copy-headers"]').click();
       const parsed = await readClipboardJson<Record<string, string>>(page);
       expect(parsed["X-Sample"]).toBe("value");
@@ -620,7 +627,7 @@ test.describe("Endpoint screen", () => {
       request,
     }) => {
       await send(request, `${endpointUrl}?a=1&b=2`, { data: "x" });
-      const card = page.locator('[data-test="request"]').first();
+      const card = newestCard(page);
       await card.locator('[data-test="copy-query"]').click();
       expect(await readClipboard(page)).toBe("a=1&b=2");
     });
@@ -634,8 +641,8 @@ test.describe("Endpoint screen", () => {
         data: raw,
         headers: { "Content-Type": "application/json", "X-Sample": "value" },
       });
-      const uuid = response.headers()["httphq-request-uuid"];
-      const card = page.locator(`#request-${uuid}`);
+      const uuid = capturedUuid(response);
+      const card = cardFor(page, uuid);
       await expect(card).toBeAttached();
 
       await card.locator('[data-test="copy-request-har"]').click();
@@ -670,7 +677,7 @@ test.describe("Endpoint screen", () => {
       request,
     }) => {
       await send(request, endpointUrl, { data: "x" });
-      const card = page.locator('[data-test="request"]').first();
+      const card = newestCard(page);
       await card.locator('[data-test="copy-request-har"]').click();
       const har = await readClipboardJson<HarDocument>(page);
 
@@ -681,7 +688,7 @@ test.describe("Endpoint screen", () => {
 
     test("a bodyless request omits postData", async ({ page, request }) => {
       await send(request, endpointUrl, { method: "GET" });
-      const card = page.locator('[data-test="request"]').first();
+      const card = newestCard(page);
       await card.locator('[data-test="copy-request-har"]').click();
       const har = await readClipboardJson<HarDocument>(page);
 
@@ -694,7 +701,7 @@ test.describe("Endpoint screen", () => {
       request,
     }) => {
       await send(request, endpointUrl, { data: "x" });
-      const card = page.locator('[data-test="request"]').first();
+      const card = newestCard(page);
       await card.locator('[data-test="copy-request-har"]').click();
       await expect(
         card.locator('[data-test="copy-request-har-label"]'),
@@ -726,9 +733,7 @@ test.describe("Endpoint screen", () => {
     }) => {
       await send(request, endpointUrl, { data: "p" });
       await send(request, endpointUrl, { method: "PUT", data: "u" });
-      await expect(page.locator('[data-test="search-results"]')).toContainText(
-        "2 results",
-      );
+      await expect(resultCount(page)).toContainText("2 results");
 
       await page.locator('[data-test="method-filter"]').selectOption("PUT");
       await expect(
@@ -840,7 +845,7 @@ test.describe("Endpoint screen", () => {
       await page.locator('[data-test="send-body"]').fill('{"hello":"panel"}');
       await page.locator('[data-test="send-submit"]').click();
 
-      const card = page.locator('[data-test="request"]').first();
+      const card = newestCard(page);
       await expect(card).toContainText("PUT");
       await expect(card.locator('[data-test="request-headers"]')).toContainText(
         "X-Source",
@@ -857,7 +862,7 @@ test.describe("Endpoint screen", () => {
         .fill("/orders/8821?event=charge.succeeded");
       await page.locator('[data-test="send-submit"]').click();
 
-      const card = page.locator('[data-test="request"]').first();
+      const card = newestCard(page);
       await expect(card.locator('[data-test="request-path"]')).toContainText(
         `${endpointPath}/orders/8821?event=charge.succeeded`,
       );

--- a/e2e/tests/har-export.spec.ts
+++ b/e2e/tests/har-export.spec.ts
@@ -1,0 +1,242 @@
+import { test, expect } from "@playwright/test";
+import {
+  buildHar,
+  loadPageScripts,
+  type CapturedRequest,
+} from "./support/harness";
+
+/**
+ * The clipboard export, driven directly. The endpoint screen already covers
+ * what a copied request looks like end to end; this covers the shapes traffic
+ * cannot put in front of the exporter. A header that repeated on the wire is
+ * stored as an array, and a body that is not ASCII is measured in bytes rather
+ * than characters, and neither survives the round trip through Playwright's
+ * request API and the server's own normalising.
+ */
+
+/** A capture with every field populated, overridden per test. */
+const capture = (fields: Partial<CapturedRequest> = {}): CapturedRequest => ({
+  uuid: "00000000-0000-4000-8000-000000000000",
+  endpointId: "e2e-fixture",
+  ip: "203.0.113.7",
+  method: "POST",
+  path: "/to/e2e-fixture",
+  queryString: "",
+  body: "",
+  createdAt: "2026-08-09T07:20:05.123Z",
+  headers: {},
+  ...fields,
+});
+
+test.describe("HAR export", () => {
+  test.beforeEach(async ({ page }) => {
+    await loadPageScripts(page);
+  });
+
+  test.describe("Envelope", () => {
+    test("names httphq as the creator", async ({ page }) => {
+      const har = await buildHar(page, [capture()]);
+
+      expect(har.creator).toEqual({ name: "httphq", version: "1" });
+    });
+
+    // A single request and a whole list share one envelope, so a consumer
+    // parses the same shape whichever button produced the document.
+    test("captures keep the order they were given", async ({ page }) => {
+      const har = await buildHar(page, [
+        capture({ uuid: "newest", body: "second" }),
+        capture({ uuid: "oldest", body: "first" }),
+      ]);
+
+      expect(har.entries.map((entry) => entry.id)).toEqual([
+        "newest",
+        "oldest",
+      ]);
+    });
+
+    // Reached when the page holds nothing. The envelope still has to parse, or
+    // a consumer reading the clipboard sees a syntax error rather than an
+    // empty export.
+    test("nothing to export is still a valid document", async ({ page }) => {
+      const har = await buildHar(page, []);
+
+      expect(har.entries).toEqual([]);
+      expect(har.creator.name).toBe("httphq");
+    });
+  });
+
+  test.describe("Headers", () => {
+    // HAR represents a repeated header as one entry per value, so the stored
+    // array is expanded rather than joined into a single entry.
+    test("a repeated header becomes one entry per value", async ({ page }) => {
+      const har = await buildHar(page, [
+        capture({ headers: { "X-Trace": ["first", "second"] } }),
+      ]);
+
+      expect(har.entries[0].request.headers).toEqual([
+        { name: "X-Trace", value: "first" },
+        { name: "X-Trace", value: "second" },
+      ]);
+    });
+
+    test("a single-valued header becomes one entry", async ({ page }) => {
+      const har = await buildHar(page, [
+        capture({ headers: { "X-Trace": "only" } }),
+      ]);
+
+      expect(har.entries[0].request.headers).toEqual([
+        { name: "X-Trace", value: "only" },
+      ]);
+    });
+
+    test("a capture with no headers exports an empty list", async ({
+      page,
+    }) => {
+      const har = await buildHar(page, [capture({ headers: {} })]);
+
+      expect(har.entries[0].request.headers).toEqual([]);
+    });
+  });
+
+  test.describe("Request URL", () => {
+    // A capture taken through one hostname has to round-trip to that hostname,
+    // not to whichever host the reader happens to have the page open on.
+    test("the captured Host header names the host", async ({ page }) => {
+      const har = await buildHar(page, [
+        capture({ headers: { Host: "hooks.example.com" } }),
+      ]);
+
+      expect(har.entries[0].request.url).toBe(
+        "http://hooks.example.com/to/e2e-fixture",
+      );
+    });
+
+    test("a capture that stored no Host falls back to the page's", async ({
+      page,
+    }) => {
+      const har = await buildHar(page, [capture()]);
+
+      expect(har.entries[0].request.url).toBe(
+        `${new URL(page.url()).origin}/to/e2e-fixture`,
+      );
+    });
+
+    test("the query string is carried on the URL as well", async ({ page }) => {
+      const har = await buildHar(page, [
+        capture({
+          headers: { Host: "hooks.example.com" },
+          queryString: "a=1&b=2",
+        }),
+      ]);
+
+      expect(har.entries[0].request.url).toBe(
+        "http://hooks.example.com/to/e2e-fixture?a=1&b=2",
+      );
+    });
+  });
+
+  test.describe("Query string", () => {
+    test("each parameter becomes a name and a value", async ({ page }) => {
+      const har = await buildHar(page, [capture({ queryString: "a=1&b=2" })]);
+
+      expect(har.entries[0].request.queryString).toEqual([
+        { name: "a", value: "1" },
+        { name: "b", value: "2" },
+      ]);
+    });
+
+    // A flag-style parameter carries no value, and dropping it would lose the
+    // fact that the client sent it at all.
+    test("a parameter with no value keeps its name", async ({ page }) => {
+      const har = await buildHar(page, [capture({ queryString: "debug" })]);
+
+      expect(har.entries[0].request.queryString).toEqual([
+        { name: "debug", value: "" },
+      ]);
+    });
+
+    test("a repeated parameter keeps every occurrence", async ({ page }) => {
+      const har = await buildHar(page, [
+        capture({ queryString: "tag=a&tag=b" }),
+      ]);
+
+      expect(har.entries[0].request.queryString).toEqual([
+        { name: "tag", value: "a" },
+        { name: "tag", value: "b" },
+      ]);
+    });
+
+    test("no query string exports an empty list", async ({ page }) => {
+      const har = await buildHar(page, [capture()]);
+
+      expect(har.entries[0].request.queryString).toEqual([]);
+    });
+  });
+
+  test.describe("Body", () => {
+    test("the body is carried verbatim under its own media type", async ({
+      page,
+    }) => {
+      const har = await buildHar(page, [
+        capture({
+          body: '{"hello":"world"}',
+          headers: { "Content-Type": "application/json" },
+        }),
+      ]);
+
+      expect(har.entries[0].request.postData).toEqual({
+        mimeType: "application/json",
+        text: '{"hello":"world"}',
+      });
+    });
+
+    // Everything that reports a size measures what was stored, which is bytes.
+    // Counting characters would under-report every payload that is not ASCII:
+    // this body is 11 bytes and 8 UTF-16 units.
+    test("the size is measured in bytes, not characters", async ({ page }) => {
+      const body = "naïve 🙂";
+      const har = await buildHar(page, [capture({ body })]);
+
+      expect(har.entries[0].request.bodySize).toBe(11);
+      expect(har.entries[0].request.bodySize).not.toBe(body.length);
+    });
+
+    // HAR leaves postData absent rather than empty when there was no payload,
+    // so a consumer can tell "sent nothing" from "sent an empty body".
+    test("a bodyless capture omits postData entirely", async ({ page }) => {
+      const har = await buildHar(page, [capture({ method: "GET" })]);
+
+      expect(har.entries[0].request).not.toHaveProperty("postData");
+      expect(har.entries[0].request.bodySize).toBe(0);
+    });
+
+    // A body that arrived without one still has to export, or a client that
+    // omitted Content-Type produces a document its own consumer cannot parse.
+    test("a body with no media type exports an empty one", async ({ page }) => {
+      const har = await buildHar(page, [capture({ body: "loose text" })]);
+
+      expect(har.entries[0].request.postData).toEqual({
+        mimeType: "",
+        text: "loose text",
+      });
+    });
+  });
+
+  test.describe("Capture metadata", () => {
+    test("the stored timestamp and client IP are carried", async ({ page }) => {
+      const har = await buildHar(page, [capture()]);
+
+      expect(har.entries[0].startedDateTime).toBe("2026-08-09T07:20:05.123Z");
+      expect(har.entries[0].clientIPAddress).toBe("203.0.113.7");
+    });
+
+    // httphq never observes the protocol, so every entry claims the same one
+    // rather than guessing per capture.
+    test("every entry claims HTTP/1.1", async ({ page }) => {
+      const har = await buildHar(page, [capture({ method: "PUT" })]);
+
+      expect(har.entries[0].request.httpVersion).toBe("HTTP/1.1");
+      expect(har.entries[0].request.method).toBe("PUT");
+    });
+  });
+});

--- a/e2e/tests/page-helpers.spec.ts
+++ b/e2e/tests/page-helpers.spec.ts
@@ -43,6 +43,118 @@ test.describe("Page helpers", () => {
     });
   });
 
+  /**
+   * The two timestamps a capture carries. They are rendered together and say
+   * different things: the clock is when it landed, the relative age is how long
+   * ago that was. A card carrying only the second goes stale on screen, and one
+   * carrying only the first leaves the reader to do the subtraction.
+   */
+  test.describe("Relative time", () => {
+    // Driven from an offset rather than a fixed date, because the helper
+    // measures against the moment it is called. Every offset is a whole number
+    // of its unit: the few milliseconds that pass inside the call would round
+    // a value sitting exactly on .5 to the neighbouring unit instead.
+    const agoFor = (page: Parameters<typeof loadPageScripts>[0], ms: number) =>
+      page.evaluate(
+        (offset) => window.formatTimeAgo(new Date(Date.now() + offset)),
+        ms,
+      );
+
+    test("crosses into the next unit at each division", async ({ page }) => {
+      const phrases = await Promise.all(
+        [-5_000, -120_000, -7_200_000, -172_800_000].map((ms) =>
+          agoFor(page, ms),
+        ),
+      );
+
+      expect(phrases).toEqual([
+        "5 seconds ago",
+        "2 minutes ago",
+        "2 hours ago",
+        "2 days ago",
+      ]);
+    });
+
+    // The capture that just landed is the one the reader is waiting on, and
+    // "0 seconds ago" reads as a stopped clock rather than a fresh arrival.
+    test("the capture that just landed reads as now", async ({ page }) => {
+      expect(await agoFor(page, 0)).toBe("now");
+    });
+  });
+
+  test.describe("Clock time", () => {
+    test("states hours, minutes and seconds", async ({ page }) => {
+      const shown = await page.evaluate(() =>
+        window.formatClock(new Date(2026, 0, 2, 13, 4, 5)),
+      );
+
+      // The viewer's locale decides between 13:04:05 and 01:04:05 PM, so this
+      // asserts the parts every locale renders rather than one arrangement of
+      // them. Seconds are the part that matters: captures arrive seconds apart,
+      // and a clock without them shows a column of identical timestamps.
+      expect(shown.split(":")).toHaveLength(3);
+      expect(shown).toContain("04");
+      expect(shown).toContain("05");
+    });
+  });
+
+  /**
+   * Header lookup, shared by body rendering and the HAR export. A stored header
+   * is a scalar or an array depending on whether it repeated on the wire (see
+   * flattenHeaders in src/capture.go), and every caller wants one value.
+   */
+  test.describe("Header lookup", () => {
+    const lookup = (
+      page: Parameters<typeof loadPageScripts>[0],
+      headers: Record<string, string | string[]> | null,
+      name: string,
+    ) =>
+      page.evaluate((args) => window.headerValue(args.headers, args.name), {
+        headers,
+        name,
+      });
+
+    // Header names are case-insensitive on the wire, and a capture stores
+    // whichever case its sender happened to use.
+    test("matches a name in any case", async ({ page }) => {
+      const found = await lookup(
+        page,
+        { "content-TYPE": "application/json" },
+        "Content-Type",
+      );
+
+      expect(found).toBe("application/json");
+    });
+
+    test("a repeated header yields its first value", async ({ page }) => {
+      const found = await lookup(
+        page,
+        { Accept: ["text/html", "*/*"] },
+        "accept",
+      );
+
+      expect(found).toBe("text/html");
+    });
+
+    test("a name that was never sent yields nothing", async ({ page }) => {
+      const found = await lookup(
+        page,
+        { Host: "example.com" },
+        "Authorization",
+      );
+
+      expect(found).toBeUndefined();
+    });
+
+    // A capture whose headers did not store is still a capture the page has to
+    // render, so the lookup answers rather than throwing.
+    test("headers absent altogether yield nothing", async ({ page }) => {
+      const found = await lookup(page, null, "Content-Type");
+
+      expect(found).toBeUndefined();
+    });
+  });
+
   test.describe("Pluralising", () => {
     // A panel that says "1 requests" reads as a defect in the thing being
     // counted rather than in the sentence counting it.

--- a/e2e/tests/support/harness.ts
+++ b/e2e/tests/support/harness.ts
@@ -67,8 +67,15 @@ declare global {
       body: string | null,
       headers: CapturedRequest["headers"] | null,
     ): string;
+    headerValue(
+      headers: CapturedRequest["headers"] | null,
+      name: string,
+    ): string | undefined;
+    buildHarExport(requests: CapturedRequest[] | null): string;
     byteLength(text: string): number;
     formatBytes(bytes: number): string;
+    formatTimeAgo(date: Date): string;
+    formatClock(date: Date): string;
     pluralize(count: number, noun: string): string;
     parseHeaderLines(text: string): {
       headers: Record<string, string>;
@@ -179,3 +186,22 @@ export type HarDocument = {
   creator: { name: string; version: string };
   entries: HarEntry[];
 };
+
+/**
+ * Runs the exporter over captures built in the test rather than over traffic.
+ * A repeated header and a body that is not ASCII both reach the exporter from a
+ * real client, but neither survives the round trip through Playwright's request
+ * API and the server's own normalising, so driving it here is what holds it to
+ * its whole contract.
+ *
+ * The parse is asserted for the same reason as listRequests: `JSON.parse`
+ * cannot know the shape it returns, so the one declaration of it stays in the
+ * harness rather than in each test.
+ */
+export const buildHar = async (
+  page: Page,
+  requests: CapturedRequest[] | null,
+): Promise<HarDocument> =>
+  JSON.parse(
+    await page.evaluate((list) => window.buildHarExport(list), requests),
+  ) as HarDocument;

--- a/public/endpoint.js
+++ b/public/endpoint.js
@@ -170,6 +170,8 @@
       _reconnectDelay: RECONNECT_MIN_MS,
       _socket: null,
       _closed: false,
+      _wsUrl: "",
+      _retentionMs: 0,
 
       // The page has exactly one store, and every reader below reaches for it.
       // Naming it once keeps the lookup out of the expressions that use it.
@@ -177,21 +179,26 @@
         return Alpine.store("main");
       },
 
-      // Alpine calls this once when the component mounts. Endpoint id and
-      // WebSocket URL come from data-* attributes on the root element so the
-      // method can match Alpine's expected `init()` signature.
+      // Alpine calls this once when the component mounts. Everything the
+      // component needs about its endpoint arrives on data-* attributes of the
+      // root element rather than as arguments, so the method can match Alpine's
+      // expected `init()` signature.
+      //
+      // The socket URL is taken as rendered rather than rebuilt from location:
+      // its ws/wss scheme has to follow the scheme the page was served over,
+      // and the server is the side that resolves that through its trusted-proxy
+      // config. See endpointURLs in src/endpoint.go.
       init() {
-        const endpointId = this.$el.dataset.endpointId;
-        if (!endpointId) return;
-        const scheme = location.protocol === "https:" ? "wss:" : "ws:";
-        this._wsUrl = `${scheme}//${location.host}/ws/${endpointId}`;
+        const { endpointId, websocketUrl, retentionSeconds } = this.$el.dataset;
+        // Neither is recoverable from the page, so a render missing either one
+        // leaves the component inert rather than pointing a socket at a guess.
+        if (!endpointId || !websocketUrl) return;
+        this._wsUrl = websocketUrl;
         // A page served without the window keeps every capture it was given
         // rather than expiring them against a guess.
-        const retentionSeconds = Number(this.$el.dataset.retentionSeconds);
+        const seconds = Number(retentionSeconds);
         this._retentionMs =
-          Number.isFinite(retentionSeconds) && retentionSeconds > 0
-            ? retentionSeconds * 1000
-            : 0;
+          Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : 0;
         this.store.setEndpoint(endpointId);
         this._connectWebSocket();
         setInterval(() => {
@@ -310,6 +317,7 @@
       formatTimeAgo: window.formatTimeAgo,
       formatClock: window.formatClock,
       formatBytes: window.formatBytes,
+      byteLength: window.byteLength,
       pluralize: window.pluralize,
       renderBody: window.renderBody,
 

--- a/src/logging/logging.go
+++ b/src/logging/logging.go
@@ -74,10 +74,9 @@ func replaceAttr(groups []string, a slog.Attr) slog.Attr {
 	return a
 }
 
-// resolveLevel picks the log level for an environment: info in production, so
-// a deployment is not paying to record its own debug chatter, and debug
-// everywhere else. An operator overrides either with LOG_LEVEL; an unrecognised
-// value leaves the environment's default in place.
+// logLevels are the values LOG_LEVEL accepts, matched case-insensitively.
+// Anything outside this set is not a level, which is what lets an unrecognised
+// override fall through to the environment's own default.
 var logLevels = map[string]slog.Level{
 	"debug": slog.LevelDebug,
 	"info":  slog.LevelInfo,
@@ -85,6 +84,10 @@ var logLevels = map[string]slog.Level{
 	"error": slog.LevelError,
 }
 
+// resolveLevel picks the log level for an environment: info in production, so
+// a deployment is not paying to record its own debug chatter, and debug
+// everywhere else. An operator overrides either with LOG_LEVEL; an unrecognised
+// value leaves the environment's default in place.
 func resolveLevel(env, override string) slog.Level {
 	if level, ok := logLevels[strings.ToLower(override)]; ok {
 		return level

--- a/src/pages.go
+++ b/src/pages.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"html/template"
 	"log/slog"
 	"maps"
 
@@ -85,10 +86,16 @@ func renderEndpoint(assets *assetIndex) fiber.Handler {
 		retention := retentionPhrase(retentionWindow)
 
 		page := fiber.Map{
-			"AppScripts":           true,
-			"EndpointID":           endpointID,
-			"EndpointURL":          endpointURL,
-			"EndpointWebSocketURL": websocketURL,
+			"AppScripts":  true,
+			"EndpointID":  endpointID,
+			"EndpointURL": endpointURL,
+			// Typed rather than passed as a string because html/template trusts
+			// only http, https and mailto in a URL attribute, and rewrites
+			// anything else to #ZgotmplZ. The value is safe to exempt: its
+			// scheme is derived here from c.Scheme(), and its endpoint ID has
+			// already passed requireValidEndpoint. Attribute escaping still
+			// applies, so the host cannot break out of the attribute.
+			"EndpointWebSocketURL": template.URL(websocketURL),
 			// The page drops captures from its own list once they age out, so it
 			// needs the window as a number rather than as the prose it renders.
 			"RetentionSeconds": int(retentionWindow.Seconds()),

--- a/src/pages_test.go
+++ b/src/pages_test.go
@@ -75,13 +75,22 @@ func TestRenderContact(t *testing.T) {
 }
 
 func TestRenderEndpoint(t *testing.T) {
+	// The page script opens the feed against the URL rendered here rather than
+	// rebuilding it, so a socket URL the page never carries is a page whose feed
+	// never connects.
 	t.Run("advertises its capture and socket URLs", func(t *testing.T) {
 		id := endpointID(t)
 		body := bodyOf(t, get(t, "/"+id))
 
 		assert.Contains(t, body, "http://example.com/to/"+id)
 		assert.Contains(t, body, `data-endpoint-id="`+id+`"`)
+		assert.Contains(t, body, `data-websocket-url="ws://example.com/ws/`+id+`"`)
 		assert.Contains(t, body, "endpoint.js?v=")
+
+		// html/template rewrites a URL attribute it does not trust to this
+		// sentinel rather than failing, so an untyped ws:// URL would render a
+		// page that looks intact and never opens its feed.
+		assert.NotContains(t, body, "ZgotmplZ")
 	})
 
 	// The page expires captures out of its own list, so it needs the window as

--- a/src/views/endpoint.html
+++ b/src/views/endpoint.html
@@ -4,6 +4,7 @@
   class="flex-1 pb-12"
   x-data="endpointPage"
   data-endpoint-id="{{.EndpointID}}"
+  data-websocket-url="{{.EndpointWebSocketURL}}"
   data-retention-seconds="{{.RetentionSeconds}}"
 >
   <h1 class="sr-only">Captured requests for {{.EndpointID}}</h1>
@@ -559,7 +560,7 @@
               <span
                 class="normal-case font-normal"
                 x-show="request.body"
-                x-text="`(${formatBytes(request.body.length)})`"
+                x-text="`(${formatBytes(byteLength(request.body))})`"
               ></span>
             </h3>
             <button


### PR DESCRIPTION
Two defects survived the recent refactors. The body badge counted UTF-16 units, not bytes, so a 200-byte payload read "100 B" beside a Content-Length of 200. Separately, renderEndpoint built a socket URL that no template rendered, so the page script derived its own. This PR fixes both, reattaches an orphaned doc comment, refiles a stray test, and adds missing coverage.

The socket URL needs template.URL, because html/template rewrites a ws:// attribute to #ZgotmplZ. Its scheme comes from c.Scheme(), and its ID passed requireValidEndpoint. The attribute escaper still runs. No route, payload, or public API changes. Thirteen test names change but assert the same behaviour.

1. Run `go test ./src/...`.
2. Build with `CGO_ENABLED=0 go build -o ./bin/httphq ./src`.
3. Run `cd e2e && npx playwright test`.
4. Start `./bin/httphq`.
5. Open any endpoint page.
6. Confirm the indicator reads Live.
7. Post a body of accented characters.
8. Confirm the badge matches Content-Length.
