### PR TITLE
Build the image in the pipeline both paths run

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -134,6 +134,28 @@ jobs:
       - run: CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /tmp/httphq ./src
         timeout-minutes: 3
 
+  # The binary above is built from the checkout; the image is built from the
+  # subset of it the Dockerfile copies. Only this catches a build input the
+  # Dockerfile does not know about, and release.yml pushes an image it never
+  # built anywhere else, so the two paths would disagree without it. Nothing is
+  # pushed here: the registry is release.yml's business.
+  image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        timeout-minutes: 1
+      - uses: docker/setup-buildx-action@v4
+        timeout-minutes: 2
+      - uses: docker/build-push-action@v7
+        timeout-minutes: 10
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
This workflow opens by saying a check cannot exist on pull requests yet be skipped on the push that publishes the image. The image build was exactly that check. `release.yml` built it, nothing else did, and a pull request reported nothing about it.

The distinction matters because the binary is built from the checkout and the image from the subset of it the Dockerfile copies. A build input the Dockerfile does not know about fails there and nowhere else. A sibling repository published nothing from a green pull request for that reason. Nothing is pushed here, and the registry stays release.yml business.

1. Confirm this pull request runs an image job rather than skipping one.
2. Run `docker build -t httphq-verify .` locally.
3. Run the image with `-p 8099:8080`.
4. Request `/` and confirm it answers 200.
5. Confirm the response CSP names `connect-src self` and no websocket wildcard.