### PR TITLE
Mint endpoint ids from crypto/rand

### DIFF
--- a/src/pages.go
+++ b/src/pages.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"crypto/rand"
 	"html/template"
 	"log/slog"
 	"maps"
+	"math/big"
 
 	"github.com/atrox/haikunatorgo/v2"
 	"github.com/gofiber/fiber/v3"
@@ -113,12 +115,60 @@ func renderEndpoint(assets *assetIndex) fiber.Handler {
 	}
 }
 
+// endpointTokenChars omits the characters that are read back wrongly off a
+// screen (i/l/1, o/0), so an ID someone retypes lands on the endpoint they
+// meant. Every character is one the endpoint ID pattern already accepts.
+const endpointTokenChars = "abcdefghjkmnpqrstuvwxyz23456789"
+
+// endpointTokenLength gives the token about 60 bits on top of the word pair.
+const endpointTokenLength = 12
+
+// randomIndex draws from crypto/rand rather than the math/rand source
+// haikunator carries. That source is seeded once from the clock, so recovering
+// the seed yields every ID a process will mint; it is also documented as unsafe
+// for concurrent use, and endpoints are minted from per-request goroutines.
+func randomIndex(n int) (int, error) {
+	index, err := rand.Int(rand.Reader, big.NewInt(int64(n)))
+	if err != nil {
+		return 0, err
+	}
+	return int(index.Int64()), nil
+}
+
+// newEndpointID builds "adjective-noun-token". The words come from
+// haikunator's lists, so the ID stays readable and shareable, but every choice
+// is drawn from crypto/rand.
+func newEndpointID(words *haikunator.Haikunator) (string, error) {
+	adjectiveIndex, err := randomIndex(len(words.Adjectives))
+	if err != nil {
+		return "", err
+	}
+	nounIndex, err := randomIndex(len(words.Nouns))
+	if err != nil {
+		return "", err
+	}
+	token := make([]byte, endpointTokenLength)
+	for i := range token {
+		charIndex, err := randomIndex(len(endpointTokenChars))
+		if err != nil {
+			return "", err
+		}
+		token[i] = endpointTokenChars[charIndex]
+	}
+	return words.Adjectives[adjectiveIndex] + "-" + words.Nouns[nounIndex] +
+		"-" + string(token), nil
+}
+
 // createEndpoint mints an endpoint ID and sends the caller to its page. The ID
-// is the only thing protecting a stream, so it comes from a generator with
-// enough room that guessing one is not a search worth running.
+// is the only thing protecting a stream, and these streams routinely capture
+// webhooks carrying credentials, so it has to be unguessable rather than merely
+// unlikely to repeat.
 func createEndpoint(haikuMaker *haikunator.Haikunator) fiber.Handler {
 	return func(c fiber.Ctx) error {
-		endpointID := haikuMaker.Haikunate()
+		endpointID, err := newEndpointID(haikuMaker)
+		if err != nil {
+			return err
+		}
 		slog.InfoContext(c.Context(), "endpoint created", "endpoint_id", endpointID)
 		return c.Redirect().To("/" + endpointID)
 	}

--- a/src/pages_test.go
+++ b/src/pages_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/atrox/haikunatorgo/v2"
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/assert"
 )
@@ -129,5 +131,56 @@ func TestCreateEndpoint(t *testing.T) {
 		location := response.Header.Get(fiber.HeaderLocation)
 		assert.True(t, validEndpointID(strings.TrimPrefix(location, "/")),
 			"generated endpoint %q must satisfy the validator every route applies", location)
+	})
+}
+
+// The endpoint ID is the only thing protecting a capture stream, and those
+// streams routinely hold webhooks carrying credentials. These assert the three
+// properties that makes necessary: enough room that ids do not repeat, an
+// unpredictable source, and safety when minted from concurrent requests.
+func TestNewEndpointID(t *testing.T) {
+	words := haikunator.New()
+
+	t.Run("emits an id the routes accept", func(t *testing.T) {
+		id, err := newEndpointID(words)
+
+		assert.NoError(t, err)
+		assert.Regexp(t, endpointIDPattern, id)
+	})
+
+	t.Run("does not repeat across many mints", func(t *testing.T) {
+		seen := make(map[string]struct{}, 10000)
+		for range 10000 {
+			id, err := newEndpointID(words)
+			assert.NoError(t, err)
+			_, duplicate := seen[id]
+			assert.False(t, duplicate, "minted a duplicate endpoint id: %s", id)
+			seen[id] = struct{}{}
+		}
+	})
+
+	// haikunator's own generator is documented as unsafe for concurrent use,
+	// and endpoints are minted from Fiber's per-request goroutines, so this is
+	// the case that has to hold under -race.
+	t.Run("is safe to mint concurrently", func(t *testing.T) {
+		var group sync.WaitGroup
+		ids := make([]string, 64)
+		for i := range ids {
+			group.Add(1)
+			go func() {
+				defer group.Done()
+				id, err := newEndpointID(words)
+				assert.NoError(t, err)
+				ids[i] = id
+			}()
+		}
+		group.Wait()
+
+		unique := make(map[string]struct{}, len(ids))
+		for _, id := range ids {
+			assert.Regexp(t, endpointIDPattern, id)
+			unique[id] = struct{}{}
+		}
+		assert.Len(t, unique, len(ids))
 	})
 }


### PR DESCRIPTION
The endpoint id is the only thing protecting a capture stream, and those streams routinely hold webhooks carrying credentials. It came from haikunator's defaults: 91 adjectives times 96 nouns times a 4-digit token, about 2^26. Inside the 4-hour retention window that is roughly a 13% chance of a collision once a few thousand endpoints are live, and nothing checked the id against the database.

The generator was also seeded once from the clock, so recovering the seed yields every id a process will mint. Its source is unsafe for concurrent use, and endpoints are minted from per-request goroutines: running the old one concurrently under `-race` reports the race. This keeps the readable prefix and draws every choice from crypto/rand.

1. Run `go test -race ./src/...`.
2. Start the app and create an endpoint.
3. Confirm the URL still reads as adjective-noun-token.
4. Confirm the page captures a request.